### PR TITLE
fix facebook link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -191,7 +191,7 @@ greyColorDark = "#777777"
 
     [[Languages.en.socialIcon]]
       icon = "ti-facebook"
-      URL = "https://www.facebook.com/GRASSGISCommunity"
+      URL = "https://www.facebook.com/groups/grass"
 
     [[Languages.en.socialIcon]]
       icon = "ti-youtube"


### PR DESCRIPTION
https://www.facebook.com/GRASSGISCommunity doesn't exist. Let's redirect to already existing Facebook group https://www.facebook.com/groups/grass