### PR TITLE
Fix HTML tags display for hugo >0.60

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,9 @@ greyColorDark = "#A0A0A0"
   changefreq = "monthly"
   filename = "sitemap.xml"
   priority = 0.5
+
+[markup]
+  defaultMarkdownHandler = "blackfriday"
   
 [Languages]
 


### PR DESCRIPTION
As explained here: https://jdhao.github.io/2019/12/29/hugo_html_not_shown/, starting from hugo version 0.60, the HTML tags are no longer displayed by default because hugo has changed the Markdown renderer from blackfriday to goldmark.

Hence, one of the proposed solutions is adding blackfriday back in the `config.toml` file as in this PR

See #12 