### PR TITLE
WIP: fixing and homogenenizing style in detailed releases list

### DIFF
--- a/content/about/history.md
+++ b/content/about/history.md
@@ -98,7 +98,7 @@ On Dec 9, 2007 GRASS GIS started to use
 and [Trac](https://trac.osgeo.org/grass) bug tracker hosted by 
 OSGeo. Other GRASS GIS project infrastructure like the website and mailing 
 lists were (and still are) hosted by OSGeo. Just for fun have a look
-at the <a href="/about/history/web-evolution">GRASS GIS Website evolution</a>.
+at the [GRASS GIS Website evolution](/about/history/web-evolution) page.
 
 In 2013, **we became 30!** Have a look at this nice article from ERDC’s CERL:
 [GRASS GIS turns 30 – ERDC’s CERL was there at the start](http://www.erdc.usace.army.mil/Media/News-Stories/Article/476565/grass-gis-turns-30-erdcs-cerl-was-there-at-the-start/)
@@ -111,4 +111,5 @@ See the [details](https://trac.osgeo.org/grass/wiki/GitMigration).
 
 ### GRASS GIS releases
 
-See the detailed GRASS GIS [releases page](/about/history/releases.md)
+See the [releases page](/about/history/releases) for the full list of releases
+since 1982 and other historic milestones. 

--- a/content/about/history/releases.md
+++ b/content/about/history/releases.md
@@ -99,7 +99,7 @@ layout: "general"
 <li>10 Mar 2005 <strong>GRASS GIS 6.0.0</strong> released: <a href="grass60/source/ChangeLog_6.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
 <li>4 Feb 2005 GRASS GIS 6.0.0beta2 released: <a href="grass60/source/ChangeLog_beta2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
 <li>12 Jan 2005 GRASS GIS 6.0.0beta1 released: <a href="grass60/source/ChangeLog_beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a>
-<div style="margin: 5px;" align="center"><img src="uploads/images/grass_5_6_roadmap_graphic.jpg" alt="" width="664" height="277" /></div>
+<div style="margin: 5px;" align="center"><img src="/static/images/gallery/development/grass_5_6_roadmap_graphic.jpg" alt="" width="664" height="277" /></div>
 </li>
 <li>5 Nov 2004 GRASS GIS 5.4.0 released: <a href="grass54/source/NEWS.html">NEWS</a> - <a href="grass54/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass54/source/">Source Code</a> - <a href="https://trac.osgeo.org/grass/log/grass/branches/releasebranch_5_4">branch</a></li>
 <li>17 Jun 2004 GRASS GIS 5.7.0 released: <a href="grass57/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass57/source/">Source Code</a></li>

--- a/content/about/history/releases.md
+++ b/content/about/history/releases.md
@@ -5,193 +5,173 @@ layout: "general"
 ---
 
 <ul>
-<li><strong>Latest 7.x releases: see <a href="https://github.com/OSGeo/grass/releases">here</a></strong></li>
+<li><strong>Latest 7.x releases</strong>: see <a href="https://github.com/OSGeo/grass/releases">here</a></li>
 <li>4 Aug 2019 Creation of the GRASS GIS <strong>7.8 release branch</strong> (<a href="https://github.com/OSGeo/grass/tree/releasebranch_7_8">d4879d4</a>)</li>
 <!-- find with git log releasebranch_7_8 --not master -->
-<li>19 Mar 2019 released <strong>GRASS GIS 7.6.1</strong>: <a href="grass76/source/ChangeLog_7.6.1.gz">HISTORY (ChangeLog)</a> - <a href="grass76/source/">Source Code</a></li>
-<li>17 Jan 2019 released <strong>GRASS GIS 7.6.0</strong>: <a href="grass76/source/ChangeLog_7.6.0.gz">HISTORY (ChangeLog)</a> - <a href="grass76/source/">Source Code</a></li>
-<li>4 Jan 2019 released <strong>GRASS GIS 7.4.4</strong>: <a href="grass74/source/ChangeLog_7.4.4.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
-<li>26 Nov 2018 released <strong>GRASS GIS 7.4.3</strong>: <a href="grass74/source/ChangeLog_7.4.3.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
-<li>22 Oct 2018 released <strong>GRASS GIS 7.4.2</strong>: <a href="grass74/source/ChangeLog_7.4.2.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
+<li>19 Mar 2019 <strong>GRASS GIS 7.6.1</strong> released: <a href="grass76/source/ChangeLog_7.6.1.gz">HISTORY (ChangeLog)</a> - <a href="grass76/source/">Source Code</a></li>
+<li>17 Jan 2019 <strong>GRASS GIS 7.6.0</strong> released: <a href="grass76/source/ChangeLog_7.6.0.gz">HISTORY (ChangeLog)</a> - <a href="grass76/source/">Source Code</a></li>
+<li>4 Jan 2019 <strong>GRASS GIS 7.4.4</strong> released: <a href="grass74/source/ChangeLog_7.4.4.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
+<li>26 Nov 2018 <strong>GRASS GIS 7.4.3</strong> released: <a href="grass74/source/ChangeLog_7.4.3.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
+<li>22 Oct 2018 <strong>GRASS GIS 7.4.2</strong> released: <a href="grass74/source/ChangeLog_7.4.2.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
 <li>31 Aug 2018 Creation of the GRASS GIS <strong>7.6 release branch</strong> (<a href="https://trac.osgeo.org/grass/changeset/73210/grass/branches/releasebranch_7_6">r73210</a>)</li>
-<li>12 Jun 2018 released <strong>GRASS GIS 7.4.1</strong>: <a href="grass74/source/ChangeLog_7.4.1.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
-<li>1 Mar 2018 released <strong>GRASS GIS 7.0.6 LTS</strong>: <a href="grass70/source/ChangeLog_7.0.6.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>26 Jan 2018 released <strong>GRASS GIS 7.4.0</strong>: <a href="grass74/source/ChangeLog_7.4.0.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
+<li>12 Jun 2018 <strong>GRASS GIS 7.4.1</strong> released: <a href="grass74/source/ChangeLog_7.4.1.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
+<li>1 Mar 2018 <strong>GRASS GIS 7.0.6 LTS</strong> released: <a href="grass70/source/ChangeLog_7.0.6.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>26 Jan 2018 <strong>GRASS GIS 7.4.0</strong> released: <a href="grass74/source/ChangeLog_7.4.0.gz">HISTORY (ChangeLog)</a> - <a href="grass74/source/">Source Code</a></li>
 <li>12 Nov 2017 Creation of the GRASS GIS <strong>7.4 release branch</strong> (<a href="https://trac.osgeo.org/grass/changeset/71701/grass/branches/releasebranch_7_4">r71701</a>)</li>
-<li>16 Sep 2017 released <strong>GRASS GIS 7.2.2</strong>: <a href="grass72/source/ChangeLog_7.2.2.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
-<li>3 May 2017 released <strong>GRASS GIS 7.2.1</strong>: <a href="grass72/source/ChangeLog_7.2.1.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
-<li>28 Dec 2016 released <strong>GRASS GIS 7.2.0</strong>: <a href="grass72/source/ChangeLog_7.2.0.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
-<li>27 Nov 2016 released GRASS GIS 7.2.0RC2: <a href="grass72/source/ChangeLog_7.2.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
-<li>27 Oct 2016 released GRASS GIS 7.2.0RC1: <a href="grass72/source/ChangeLog_7.2.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
-<li>2 Oct 2016 released <strong>GRASS GIS 7.0.5</strong>: <a href="grass70/source/ChangeLog_7.0.5.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>16 Sep 2017 <strong>GRASS GIS 7.2.2</strong> released: <a href="grass72/source/ChangeLog_7.2.2.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
+<li>3 May 2017 <strong>GRASS GIS 7.2.1</strong> released: <a href="grass72/source/ChangeLog_7.2.1.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
+<li>28 Dec 2016 <strong>GRASS GIS 7.2.0</strong> released: <a href="grass72/source/ChangeLog_7.2.0.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
+<li>27 Nov 2016 GRASS GIS 7.2.0RC2 released: <a href="grass72/source/ChangeLog_7.2.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
+<li>27 Oct 2016 GRASS GIS 7.2.0RC1 released: <a href="grass72/source/ChangeLog_7.2.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass72/source/">Source Code</a></li>
+<li>2 Oct 2016 <strong>GRASS GIS 7.0.5</strong> released: <a href="grass70/source/ChangeLog_7.0.5.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
 <li>24 May 2016 Creation of the GRASS GIS <strong>7.2 release branch</strong> (<a href="https://trac.osgeo.org/grass/changeset/68500/grass/branches/releasebranch_7_2">r68500</a>)</li>
-<li>1 May 2016 released <strong>GRASS GIS 7.0.4</strong>: <a href="grass70/source/ChangeLog_7.0.4.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>18 Apr 2016 released GRASS GIS 7.0.4RC1: <a href="grass70/source/ChangeLog_7.0.4RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>28 Jan 2016 released <strong>GRASS GIS 7.0.3</strong>: <a href="grass70/source/ChangeLog_7.0.3.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>15 Jan 2016 released GRASS GIS 7.0.3RC2: <a href="grass70/source/ChangeLog_7.0.3RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>31 Dec 2015 released GRASS GIS 7.0.3RC1: <a href="grass70/source/ChangeLog_7.0.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>19 Nov 2015 released <strong>GRASS GIS 7.0.2</strong>: <a href="grass70/source/ChangeLog_7.0.2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>3 Nov 2015 released GRASS GIS 7.0.2RC2: <a href="grass70/source/ChangeLog_7.0.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>19 Oct 2015 released GRASS GIS 7.0.2RC1: <a href="grass70/source/ChangeLog_7.0.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>30 Jul 2015 released <strong>GRASS GIS 7.0.1</strong>: <a href="grass70/source/ChangeLog_7.0.1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>20 Jul 2015 released GRASS GIS 7.0.1RC1: <a href="grass70/source/ChangeLog_7.0.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>20 Feb 2015 released <strong>GRASS GIS 7.0.0</strong>: <a href="grass70/source/ChangeLog_7.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>12 Jul 2015 released GRASS GIS 6.4.5: <a href="grass64/source/ChangeLog_6.4.5.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>6 Apr 2015 released GRASS GIS 6.4.5RC1: <a href="grass64/source/ChangeLog_6.4.5RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>20 Feb 2015 released <strong>GRASS GIS 7.0.0</strong>: <a href="grass70/source/ChangeLog_7.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>08 Feb 2015 released GRASS GIS 7.0.0RC2: <a href="grass70/source/ChangeLog_7.0.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>14 Jan 2015 released GRASS GIS 7.0.0RC1: <a href="grass70/source/ChangeLog_7.0.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
-<li>25 Jun 2014 released GRASS GIS 6.4.4: <a href="grass64/source/ChangeLog_6.4.4.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>14 Jun 2014 released GRASS GIS 6.4.4RC1: <a href="grass64/source/ChangeLog_6.4.4RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>27 Mar 2014 Creation of the GRASS GIS <strong>7.0 release branch</strong> (<a href="https://trac.osgeo.org/grass/changeset/59487/grass/branches/releasebranch_7_0">r59487</a>; development started in Apr 2008, <a href="https://trac.osgeo.org/grass/changeset/31142">r31142</a>)</li>
-<li>27 Jul 2013 released GRASS GIS 6.4.3: <a href="grass64/source/ChangeLog_6.4.3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a> - <strong>Birthday release for <a href="news/27/84/30-years-of-GRASS-GIS-development">30 years of GRASS GIS</a></strong></li>
-<li>20 Apr 2013 released GRASS 6.4.3RC3: <a href="grass64/source/ChangeLog_6.4.3RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>18 Dec 2012 released GRASS 6.4.3RC2: <a href="grass64/source/ChangeLog_6.4.3RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>24 Oct 2012 released GRASS 6.4.3RC1: <a href="grass64/source/ChangeLog_6.4.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li></li>
-<li>19 Feb 2012 released GRASS 6.4.2: <a href="grass64/source/ChangeLog_6.4.2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-</ul>
-<ul>
-<li>12 Jan 2012 released GRASS 6.4.2RC3: <a href="grass64/source/ChangeLog_6.4.2RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-</ul>
-<ul>
-<li>15 Nov 2011 released GRASS 6.4.2RC2: <a href="grass64/source/ChangeLog_6.4.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-</ul>
-<ul>
-<li>10 Oct 2011 released GRASS 6.4.2RC1: <a href="grass64/source/ChangeLog_6.4.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-</ul>
-<ul>
-<li>12 Apr 2011 released GRASS 6.4.1: <a href="grass64/source/ChangeLog_6.4.1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-</ul>
-<ul>
-<li>17 Mar 2011 released GRASS 6.4.1RC2: <a href="grass64/source/ChangeLog_6.4.1RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>3 Sep 2010 released <strong>GRASS GIS 6.4.0</strong>: <a href="grass64/source/ChangeLog_6.4.0.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>27 Aug 2010 released GRASS 6.4.0RC7 : <a href="grass64/source/ChangeLog_6.4.0RC7.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>20 Mar 2010 released GRASS 6.4.0RC6 : <a href="grass64/source/ChangeLog_6.4.0RC6.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>9 Jun 2009 released GRASS 6.4.0RC5 : <a href="grass64/source/ChangeLog_6.4.0RC5.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>12 Apr 2009 released GRASS 6.4.0RC4 : <a href="grass64/source/ChangeLog_6.4.0RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>26 Jan 2009 released GRASS 6.4.0RC3 : <a href="grass64/source/ChangeLog_6.4.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>12 Jan 2009 released GRASS 6.4.0RC2 : <a href="grass64/source/ChangeLog_6.4.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>23 Dec 2008 released GRASS 6.4.0RC1 : <a href="grass64/source/ChangeLog_6.4.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
-<li>27 April 2008 <strong>GRASS GIS 7 development begun in <a href="http://trac.osgeo.org/grass/changeset/31142">r31142</a><br /></strong></li>
-<li>23 Apr 2008 released GRASS 6.3.0 : <a href="grass63/source/ChangeLog_6.3.0.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>21 Mar 2008 released GRASS 6.3.0RC6 : <a href="grass63/source/ChangeLog_6.3.0RC6.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>19 Feb 2008 released GRASS 6.3.0RC5 : <a href="grass63/source/ChangeLog_6.3.0RC5.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>9 Jan 2008 released GRASS 6.3.0RC4 : <a href="grass63/source/ChangeLog_6.3.0RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>1 May 2016 <strong>GRASS GIS 7.0.4</strong> released: <a href="grass70/source/ChangeLog_7.0.4.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>18 Apr 2016 GRASS GIS 7.0.4RC1 released: <a href="grass70/source/ChangeLog_7.0.4RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>28 Jan 2016 <strong>GRASS GIS 7.0.3</strong> released: <a href="grass70/source/ChangeLog_7.0.3.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>15 Jan 2016 GRASS GIS 7.0.3RC2 released: <a href="grass70/source/ChangeLog_7.0.3RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>31 Dec 2015 GRASS GIS 7.0.3RC1 released: <a href="grass70/source/ChangeLog_7.0.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>19 Nov 2015 <strong>GRASS GIS 7.0.2</strong> released: <a href="grass70/source/ChangeLog_7.0.2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>3 Nov 2015 GRASS GIS 7.0.2RC2 released: <a href="grass70/source/ChangeLog_7.0.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>19 Oct 2015 GRASS GIS 7.0.2RC1 released: <a href="grass70/source/ChangeLog_7.0.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>30 Jul 2015 <strong>GRASS GIS 7.0.1</strong> released: <a href="grass70/source/ChangeLog_7.0.1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>20 Jul 2015 GRASS GIS 7.0.1RC1 released: <a href="grass70/source/ChangeLog_7.0.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>12 Jul 2015 GRASS GIS 6.4.5 released: <a href="grass64/source/ChangeLog_6.4.5.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>6 Apr 2015 GRASS GIS 6.4.5RC1 released: <a href="grass64/source/ChangeLog_6.4.5RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>20 Feb 2015 <strong>GRASS GIS 7.0.0</strong> released: <a href="grass70/source/ChangeLog_7.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>8 Feb 2015 GRASS GIS 7.0.0RC2 released: <a href="grass70/source/ChangeLog_7.0.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>14 Jan 2015 GRASS GIS 7.0.0RC1 released: <a href="grass70/source/ChangeLog_7.0.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass70/source/">Source Code</a></li>
+<li>25 Jun 2014 GRASS GIS 6.4.4 released: <a href="grass64/source/ChangeLog_6.4.4.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>14 Jun 2014 GRASS GIS 6.4.4RC1 released: <a href="grass64/source/ChangeLog_6.4.4RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>27 Mar 2014 Creation of the GRASS GIS <strong>7.0 release branch</strong> (<a href="https://trac.osgeo.org/grass/changeset/59487/grass/branches/releasebranch_7_0">r59487)</a></li>
+<li>27 Jul 2013 GRASS GIS 6.4.3 released: <a href="grass64/source/ChangeLog_6.4.3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a> - <strong>Birthday release for <a href="news/27/84/30-years-of-GRASS-GIS-development">30 years of GRASS GIS</a></strong></li>
+<li>20 Apr 2013 GRASS GIS 6.4.3RC3 released: <a href="grass64/source/ChangeLog_6.4.3RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>18 Dec 2012 GRASS GIS 6.4.3RC2 released: <a href="grass64/source/ChangeLog_6.4.3RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>24 Oct 2012 GRASS GIS 6.4.3RC1 released: <a href="grass64/source/ChangeLog_6.4.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>19 Feb 2012 GRASS GIS 6.4.2 released: <a href="grass64/source/ChangeLog_6.4.2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>12 Jan 2012 GRASS GIS 6.4.2RC3 released: <a href="grass64/source/ChangeLog_6.4.2RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>15 Nov 2011 GRASS GIS 6.4.2RC2 released: <a href="grass64/source/ChangeLog_6.4.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>10 Oct 2011 GRASS GIS 6.4.2RC1 released: <a href="grass64/source/ChangeLog_6.4.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>12 Apr 2011 GRASS GIS 6.4.1 released: <a href="grass64/source/ChangeLog_6.4.1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>17 Mar 2011 GRASS GIS 6.4.1RC2 released: <a href="grass64/source/ChangeLog_6.4.1RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>3 Sep 2010 <strong>GRASS GIS 6.4.0</strong> released: <a href="grass64/source/ChangeLog_6.4.0.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>27 Aug 2010 GRASS GIS 6.4.0RC7 released: <a href="grass64/source/ChangeLog_6.4.0RC7.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>20 Mar 2010 GRASS GIS 6.4.0RC6 released: <a href="grass64/source/ChangeLog_6.4.0RC6.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>9 Jun 2009 GRASS GIS 6.4.0RC5 released: <a href="grass64/source/ChangeLog_6.4.0RC5.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>12 Apr 2009 GRASS GIS 6.4.0RC4 released: <a href="grass64/source/ChangeLog_6.4.0RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>26 Jan 2009 GRASS GIS 6.4.0RC3 released: <a href="grass64/source/ChangeLog_6.4.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>12 Jan 2009 GRASS GIS 6.4.0RC2 released: <a href="grass64/source/ChangeLog_6.4.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>23 Dec 2008 GRASS GIS 6.4.0RC1 released: <a href="grass64/source/ChangeLog_6.4.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass64/source/">Source Code</a></li>
+<li>27 Apr 2008 <strong>GRASS GIS 7 development began in <a href="http://trac.osgeo.org/grass/changeset/31142">r31142</a><br /></strong></li>
+<li>23 Apr 2008 GRASS GIS 6.3.0 released: <a href="grass63/source/ChangeLog_6.3.0.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>21 Mar 2008 GRASS GIS 6.3.0RC6 released: <a href="grass63/source/ChangeLog_6.3.0RC6.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>19 Feb 2008 GRASS GIS 6.3.0RC5 released: <a href="grass63/source/ChangeLog_6.3.0RC5.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>9 Jan 2008 GRASS GIS 6.3.0RC4 released: <a href="grass63/source/ChangeLog_6.3.0RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
 <li>1 Jan 2008 The <strong>GRASS Development Team</strong>, now headquartered at Fondazione Edmund Mach, ex IASMA (Trento, Italy)</li>
-<li>30 Nov 2007 released GRASS 6.3.0RC3 : <a href="grass63/source/ChangeLog_6.3.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>20 Nov 2007 released GRASS 6.3.0RC2 : <a href="grass63/source/ChangeLog_6.3.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>24 Oct 2007 released GRASS 6.3.0RC1 : <a href="grass63/source/ChangeLog_6.3.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
-<li>27 Nov 2007 released GRASS 6.2.3 : <a href="grass62/source/ChangeLog_6.2.3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>21 Oct 2007 released GRASS 6.2.3RC1 : <a href="grass62/source/ChangeLog_6.2.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>26 July 2007 released GRASS 5.4.1 : <a href="grass54/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass54/source/">Source Code</a></li>
-<li>16 June 2007 released GRASS 6.2.2 : <a href="grass62/source/ChangeLog_6.2.2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>29 May 2007 released GRASS 6.2.2RC1 : <a href="grass62/source/ChangeLog_6.2.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>12 Dec 2006 released GRASS 6.2.1 : <a href="grass62/source/ChangeLog_6.2.1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>6 Dec 2006 released GRASS 6.2.1RC1 : <a href="grass62/source/ChangeLog_6.2.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>31 Oct 2006 released GRASS 6.2.0 : <a href="grass62/source/ChangeLog_6.2.0.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>24 Oct 2006 released GRASS 6.2.0RC3 : <a href="grass62/source/ChangeLog_6.2.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>6 Oct 2006 released GRASS 6.2.0RC2 : <a href="grass62/source/ChangeLog_6.2.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>26 Sep 2006 released GRASS 6.2.0RC1 : <a href="grass62/source/ChangeLog_6.2.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>18 Sep 2006 released GRASS 6.2.0beta3 : <a href="grass62/source/ChangeLog_6.2.0beta3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>30 Aug 2006 released GRASS 6.2.0beta2 : <a href="grass62/source/ChangeLog_6.2.0beta2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>28 Aug 2006 released GRASS 6.2.0beta1 : <a href="grass62/source/ChangeLog_6.2.0beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
-<li>11 Aug 2006 released GRASS 6.1.0 : <a href="grass61/source/ChangeLog_6.1.0.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
-<li>2 Aug 2006 released GRASS 6.1.0RC1 : <a href="grass61/source/ChangeLog_6.1.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
-<li>14 Jul 2006 released GRASS 6.1.0beta1 : <a href="grass61/source/ChangeLog_6.1.0beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
-<li>22 Feb 2006 released GRASS 6.0.2 : <a href="grass60/source/ChangeLog_6.0.2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>6 January 2006 released GRASS 6.0.2RC4 : <a href="grass60/source/ChangeLog_6.0.2RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>3 January 2006 released GRASS 6.0.2RC3 : <a href="grass60/source/ChangeLog_6.0.2RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>3 January 2006 released GRASS 6.0.2RC2 : <a href="grass60/source/ChangeLog_6.0.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>30 Nov 2007 GRASS GIS 6.3.0RC3 released: <a href="grass63/source/ChangeLog_6.3.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>20 Nov 2007 GRASS GIS 6.3.0RC2 released: <a href="grass63/source/ChangeLog_6.3.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>24 Oct 2007 GRASS GIS 6.3.0RC1 released: <a href="grass63/source/ChangeLog_6.3.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass63/source/">Source Code</a></li>
+<li>27 Nov 2007 <strong>GRASS GIS 6.2.3</strong> released: <a href="grass62/source/ChangeLog_6.2.3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>21 Oct 2007 GRASS GIS 6.2.3RC1 released: <a href="grass62/source/ChangeLog_6.2.3RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>26 Jul 2007 GRASS GIS 5.4.1 released: <a href="grass54/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass54/source/">Source Code</a></li>
+<li>16 Jun 2007 GRASS GIS 6.2.2 released: <a href="grass62/source/ChangeLog_6.2.2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>29 May 2007 GRASS GIS 6.2.2RC1 released: <a href="grass62/source/ChangeLog_6.2.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>12 Dec 2006 GRASS GIS 6.2.1 released: <a href="grass62/source/ChangeLog_6.2.1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>6 Dec 2006 GRASS GIS 6.2.1RC1 released: <a href="grass62/source/ChangeLog_6.2.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>31 Oct 2006 <strong>GRASS GIS 6.2.0</strong> released: <a href="grass62/source/ChangeLog_6.2.0.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>24 Oct 2006 GRASS GIS 6.2.0RC3 released: <a href="grass62/source/ChangeLog_6.2.0RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>6 Oct 2006 GRASS GIS 6.2.0RC2 released: <a href="grass62/source/ChangeLog_6.2.0RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>26 Sep 2006 GRASS GIS 6.2.0RC1 released: <a href="grass62/source/ChangeLog_6.2.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>18 Sep 2006 GRASS GIS 6.2.0beta3 released: <a href="grass62/source/ChangeLog_6.2.0beta3.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>30 Aug 2006 GRASS GIS 6.2.0beta2 released: <a href="grass62/source/ChangeLog_6.2.0beta2.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>28 Aug 2006 GRASS GIS 6.2.0beta1 released: <a href="grass62/source/ChangeLog_6.2.0beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass62/source/">Source Code</a></li>
+<li>11 Aug 2006 <strong>GRASS GIS 6.1.0</strong> released: <a href="grass61/source/ChangeLog_6.1.0.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
+<li>2 Aug 2006 GRASS GIS 6.1.0RC1 released: <a href="grass61/source/ChangeLog_6.1.0RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
+<li>14 Jul 2006 GRASS GIS 6.1.0beta1 released: <a href="grass61/source/ChangeLog_6.1.0beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass61/source/">Source Code</a></li>
+<li>22 Feb 2006 GRASS GIS 6.0.2 released: <a href="grass60/source/ChangeLog_6.0.2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>6 Jan 2006 GRASS GIS 6.0.2RC4 released: <a href="grass60/source/ChangeLog_6.0.2RC4.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>3 Jan 2006 GRASS GIS 6.0.2RC3 released: <a href="grass60/source/ChangeLog_6.0.2RC3.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>3 Jan 2006 GRASS GIS 6.0.2RC2 released: <a href="grass60/source/ChangeLog_6.0.2RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
 <li>2 Jan 2006: <strong>conversion of K&amp;R C notation to ANSI C</strong> (<a href="https://lists.osgeo.org/pipermail/grass-dev/2006-January/020767.html">details,</a> <a href="http://www.antoniol.net/wp-content/papercite-data/pdf/2006/04021333.pdf">scientific article</a> and changes <a href="https://trac.osgeo.org/grass/changeset/18618">r18618</a>, <a href="https://trac.osgeo.org/grass/changeset/18619">r18619</a>, <a href="https://trac.osgeo.org/grass/changeset/18623">r18623</a>, <a href="https://trac.osgeo.org/grass/changeset/18625">r18625</a>, <a href="https://trac.osgeo.org/grass/changeset/18626">r18626</a>, <a href="https://trac.osgeo.org/grass/changeset/18627">r18627</a>, <a href="https://trac.osgeo.org/grass/changeset/18628">r18628</a>, <a href="https://trac.osgeo.org/grass/changeset/18632">r18632</a>, <a href="https://trac.osgeo.org/grass/changeset/18633">r18633</a>)</li>
-<li>29 December 2005 released GRASS 6.0.2RC1 : <a href="grass60/source/ChangeLog_6.0.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>22 August 2005 released GRASS 6.0.1 : <a href="grass60/source/ChangeLog_6.0.1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>8 August 2005 released GRASS 6.0.1RC2 : <a href="grass60/source/ChangeLog_6.0.1RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>3 August 2005 released GRASS 6.0.1RC1 : <a href="grass60/source/ChangeLog_6.0.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>10 March 2005 released GRASS 6.0.0 : <a href="grass60/source/ChangeLog_6.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>4 February 2005 released GRASS 6.0.0beta2 : <a href="grass60/source/ChangeLog_beta2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
-<li>12 January 2005 released GRASS 6.0.0beta1: <a href="grass60/source/ChangeLog_beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a>
+<li>29 Dec 2005 GRASS GIS 6.0.2RC1 released: <a href="grass60/source/ChangeLog_6.0.2RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>22 Aug 2005 GRASS GIS 6.0.1 released: <a href="grass60/source/ChangeLog_6.0.1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>8 Aug 2005 GRASS GIS 6.0.1RC2 released: <a href="grass60/source/ChangeLog_6.0.1RC2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>3 Aug 2005 GRASS GIS 6.0.1RC1 released: <a href="grass60/source/ChangeLog_6.0.1RC1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>10 Mar 2005 <strong>GRASS GIS 6.0.0</strong> released: <a href="grass60/source/ChangeLog_6.0.0.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>4 Feb 2005 GRASS GIS 6.0.0beta2 released: <a href="grass60/source/ChangeLog_beta2.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a></li>
+<li>12 Jan 2005 GRASS GIS 6.0.0beta1 released: <a href="grass60/source/ChangeLog_beta1.gz">HISTORY (ChangeLog)</a> - <a href="grass60/source/">Source Code</a>
 <div style="margin: 5px;" align="center"><img src="uploads/images/grass_5_6_roadmap_graphic.jpg" alt="" width="664" height="277" /></div>
 </li>
-<li>5 November 2004 released GRASS 5.4.0: <a href="grass54/source/NEWS.html">NEWS</a> - <a href="grass54/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass54/source/">Source Code</a> - <a href="https://trac.osgeo.org/grass/log/grass/branches/releasebranch_5_4">branch</a></li>
-<li>17 June 2004 released GRASS 5.7.0: <a href="grass57/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass57/source/">Source Code</a></li>
-<li>5 May 2004 released GRASS 5.3.0: <a href="announces/announce_grass530.html">Press release</a> – <a href="grass53/source/News.html">NEWS</a> - <a href="grass53/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass53/source/">Source Code</a></li>
-<li>6 November 2003 released GRASS 5.0.3: <a href="announces/announce_grass503.html">Press release</a> - <a href="grass50/source/ChangeLog">HISTORY (ChangeLog) of GRASS5.0beta6-11, pre1-X file with authors</a></li>
-</ul>
-<ul>
-<li>10 April 2003 released GRASS 5.0.2: <a href="announces/announce_grass502.html">Press release</a></li>
-<li>28 January 2003 released GRASS 5.0.1</li>
-<li>5 September 2002 released GRASS 5.0.0 stable: <a href="announces/press_release500.html">Press release</a></li>
-<li>25 June 2002 released GRASS 5.0.0pre5: <a href="announces/announce_grass500pre5.html">Press release</a></li>
-<li>13 May 2002 released GRASS 5.0.0pre4: <a href="announces/announce_grass500pre4.html">Press release</a></li>
-<li>16 January 2002 released GRASS 5.0.0pre3: <a href="announces/announce_grass500pre3.html">Press release</a></li>
-<li>13 September 2001 released GRASS 5.0.0pre2: <a href="announces/announce_grass500pre2.html">Press release</a></li>
-<li>20 May 2001 GRASS 5.0.0pre1 released</li>
-<li>6 December 2000 GRASS 5.0 beta9 released</li>
-<li>4 Feb 2001 GRASS 5.0 beta11 released</li>
-<li>January 2001 Request Tracker (RT) established for bug tracking</li>
+<li>5 Nov 2004 GRASS GIS 5.4.0 released: <a href="grass54/source/NEWS.html">NEWS</a> - <a href="grass54/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass54/source/">Source Code</a> - <a href="https://trac.osgeo.org/grass/log/grass/branches/releasebranch_5_4">branch</a></li>
+<li>17 Jun 2004 GRASS GIS 5.7.0 released: <a href="grass57/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass57/source/">Source Code</a></li>
+<li>5 May 2004 GRASS GIS 5.3.0 released: <a href="announces/announce_grass530.html">Press release</a> – <a href="grass53/source/News.html">NEWS</a> - <a href="grass53/source/ChangeLog">HISTORY (ChangeLog)</a> - <a href="grass53/source/">Source Code</a></li>
+<li>6 Nov 2003 GRASS GIS 5.0.3 released: <a href="announces/announce_grass503.html">Press release</a> - <a href="grass50/source/ChangeLog">HISTORY (ChangeLog) of GRASS5.0beta6-11, pre1-X file with authors</a></li>
+<li>10 Apr 2003 GRASS GIS 5.0.2 released: <a href="announces/announce_grass502.html">Press release</a></li>
+<li>28 Jan 2003 GRASS GIS 5.0.1 released</li>
+<li>5 Sep 2002 <strong>GRASS GIS 5.0.0</strong> released: <a href="announces/press_release500.html">Press release</a></li>
+<li>25 Jun 2002 GRASS GIS 5.0.0pre5 released: <a href="announces/announce_grass500pre5.html">Press release</a></li>
+<li>13 May 2002 GRASS GIS 5.0.0pre4 released: <a href="announces/announce_grass500pre4.html">Press release</a></li>
+<li>16 Jan 2002 GRASS GIS 5.0.0pre3 released: <a href="announces/announce_grass500pre3.html">Press release</a></li>
+<li>13 Sep 2001 GRASS GIS 5.0.0pre2 released: <a href="announces/announce_grass500pre2.html">Press release</a></li>
+<li>20 May 2001 GRASS GIS 5.0.0pre1 released</li>
+<li>4 Feb 2001 GRASS GIS 5.0 beta11 released</li>
+<li>Jan 2001 Request Tracker (RT) established for bug tracking</li>
 <li>2001 GRASS Europe pages moved from University of Hannover, Germany to ITC-irst, Italy</li>
 <li>2001-2008 The <strong>GRASS Development Team</strong>, now headquartered at ITC-irst (Trento, Italy)</li>
-<li>7 December 2000 GRASS 5.0 beta10 released: <a href="announces/announce_grass50beta10.html">Press release</a></li>
-<li>26 July 2000 GRASS 5 beta8 released</li>
-<li>20 Apr 2000 GRASS 5 beta7 released</li>
-<li>16 Feb 2000 GRASS 5 beta6 released: first version released from CVS - <a href="grass50/source/oldhistory/HISTORY_beta4to6.txt">HISTORY of GRASS5.0beta4-6 file with authors</a></li>
-<li>29 Dec 1999 CVS started for GRASS 5.0, see <a href="https://trac.osgeo.org/grass/changeset/9499">https://trac.osgeo.org/grass/changeset/9499</a></li>
-<li>8 Dec 1999 GRASS 5 beta5 released</li>
-<li>26 Oct 1999 GRASS 5 beta4 released: <a href="announces/gnu-release.html">GNU GPL release announcement October 23, 1999</a> - <a href="grass50/source/oldhistory/HISTORY_beta2to4.txt">HISTORY of GRASS5.0beta2-4 file with authors</a></li>
-<li>3 Sep 1999 GRASS 5 beta3 released</li>
-<li>20 July 1999 GRASS 5 beta2 released</li>
-<li>30 June 1999 GRASS 5 beta1 released</li>
+<li>7 Dec 2000 GRASS GIS 5.0 beta10 released: <a href="announces/announce_grass50beta10.html">Press release</a></li>
+<li>6 Dec 2000 GRASS GIS 5.0 beta9 released</li>
+<li>26 Jul 2000 GRASS GIS 5.0 beta8 released</li>
+<li>20 Apr 2000 GRASS GIS 5.0 beta7 released</li>
+<li>16 Feb 2000 GRASS GIS 5.0 beta6 released: first version released from CVS - <a href="grass50/source/oldhistory/HISTORY_beta4to6.txt">HISTORY of GRASS5.0beta4-6 file with authors</a></li>
+<li>29 Dec 1999 CVS started for GRASS GIS 5.0, see <a href="https://trac.osgeo.org/grass/changeset/9499">https://trac.osgeo.org/grass/changeset/9499</a></li>
+<li>8 Dec 1999 GRASS GIS 5.0 beta5 released</li>
+<li>26 Oct 1999 GRASS GIS 5.0 beta4 released: <a href="announces/gnu-release.html">GNU GPL release announcement October 23, 1999</a> - <a href="grass50/source/oldhistory/HISTORY_beta2to4.txt">HISTORY of GRASS5.0beta2-4 file with authors</a></li>
+<li>3 Sep 1999 GRASS GIS 5.0 beta3 released</li>
+<li>20 Jul 1999 GRASS GIS 5.0 beta2 released</li>
+<li>30 Jun 1999 GRASS GIS 5.0 beta1 released</li>
 <li>1999-2001 The new <strong>GRASS Development Team</strong></li>
-<li>June 1999 <a href="grass50/source/">GRASS 5.0</a> Baylor University and Markus Neteler</li>
-</ul>
-<ul>
+<li>Jun 1999 <a href="grass50/source/">GRASS 5.0</a> joint release by Baylor University and Markus Neteler</li>
 <li>Nov 1999 <a href="grass43/source/">GRASS 4.3 released</a> (based on 4.2.1V22 with a few more fixes): <a href="grass43/source/HISTORY.html">HISTORY file with authors</a></li>
-</ul>
+<li>1998-1999 GRASS GIS 4.2.1 Markus Neteler, University of Hannover, Germany with worldwide contributions (the team applied 243 fixes and 50 new modules to former 4.2, graphical user interface "TclTkGRASS" added (Jacques Bouchard), code cleanup from leftover files (more than 1000)): <a href="grass421/HISTORY.html">HISTORY file with authors</a>
 <ul>
-<li>1998-1999 GRASS 4.2.1 Markus Neteler, University of Hannover, Germany with worldwide contributions (the team applied 243 fixes and 50 new modules to former 4.2, graphical user interface "TclTkGRASS" added (Jacques Bouchard),  code cleanup from leftover files (more than 1000)): <a href="grass421/HISTORY.html">HISTORY file with authors</a>
-<ul>
-<li>GRASS 4.2.1 Version 22 released 1st November 1999</li>
-<li>GRASS 4.2.1 Version 21 (9. March 1999)</li>
-<li>GRASS 4.2.1 Version 20 (7. December 1998)</li>
-<li>GRASS 4.2.1 Version 19 (22. September 1998)</li>
-<li>GRASS 4.2.1 Version 18b (22. July 1998)</li>
-<li>GRASS 4.2.1 Version 17 (12. June 1998)</li>
-<li>GRASS 4.2.1 Version 16a (29. May 1998)</li>
-<li>GRASS 4.2.1 Version 16 (23. May 1998)</li>
-<li>GRASS 4.2.1 Version 15 (30. April 1998)</li>
-<li>GRASS 4.2.1 Version 14 (19. April 1998)</li>
-<li>GRASS 4.2.1 Version 13 (15. April 1998)</li>
-<li>GRASS 4.2.1 Version 12 (1. April 1998)</li>
-<li>GRASS 4.2.1 Version 11a (21. March 1998)</li>
-<li>GRASS 4.2.1 Version 10 (11. March 1998)</li>
-<li>GRASS 4.2.1 Version 9 (3. March 1998)</li>
-<li>GRASS 4.2.1 Version 8 (5. Feb. 1998)</li>
-<li>GRASS 4.2.1 Version 7 (4. Feb. 1998)</li>
-<li>GRASS 4.2.1 Version 6 (29. Jan. 1998)</li>
-<li>GRASS 4.2.1 Version 5 (27 Jan. 1998)</li>
-<li>GRASS 4.2.1 Version 4 (19 Jan. 1998)</li>
-<li>GRASS 4.2.1 Version 3 (11 Jan. 1998)</li>
-<li>GRASS 4.2.1 Version 2 (8 Jan. 1998)</li>
-<li>GRASS 4.2.1 Version 1 (7 Jan. 1998)</li>
+<li>1 Nov 1999 GRASS GIS 4.2.1 Version 22 released</li>
+<li>9 Mar 1999 GRASS GIS 4.2.1 Version 21 released</li>
+<li>7 Dec 1998 GRASS GIS 4.2.1 Version 20 released</li>
+<li>22 Sep 1998 GRASS GIS 4.2.1 Version 19 released</li>
+<li>22 Jul 1998 GRASS GIS 4.2.1 Version 18b released</li>
+<li>12 Jun 1998 GRASS GIS 4.2.1 Version 17 released</li>
+<li>29 May 1998 GRASS GIS 4.2.1 Version 16a released</li>
+<li>23 May 1998 GRASS GIS 4.2.1 Version 16 released</li>
+<li>30 Apr 1998 GRASS GIS 4.2.1 Version 15 released</li>
+<li>19 Apr 1998 GRASS GIS 4.2.1 Version 14 released</li>
+<li>15 Apr 1998 GRASS GIS 4.2.1 Version 13 released</li>
+<li>1 Apr 1998 GRASS GIS 4.2.1 Version 12 released</li>
+<li>21 Mar 1998 GRASS GIS 4.2.1 Version 11a released</li>
+<li>11 Mar 1998 GRASS GIS 4.2.1 Version 10 released</li>
+<li>3 Mar 1998 GRASS GIS 4.2.1 Version 9 released</li>
+<li>5 Feb 1998 GRASS GIS 4.2.1 Version 8 released</li>
+<li>4 Feb 1998 GRASS GIS 4.2.1 Version 7 released</li>
+<li>29 Jan 1998 GRASS GIS 4.2.1 Version 6 released</li>
+<li>27 Jan 1998 GRASS GIS 4.2.1 Version 5 released</li>
+<li>19 Jan 1998 GRASS GIS 4.2.1 Version 4 released</li>
+<li>11 Jan 1998 GRASS GIS 4.2.1 Version 3 released</li>
+<li>8 Jan 1998 GRASS GIS 4.2.1 Version 2 released</li>
+<li>7 Jan 1998 GRASS GIS 4.2.1 Version 1 released</li>
 </ul>
-</li>
-<li>12/1997 GRASS 4.2 Baylor University - The first "GRASS Research Group" takes control of GRASS Development from USACERL. Extended sites format. This first new <a href="grass42/">GRASS 4.2 release</a> in 4 years adds numerous programs. Popularity increases with academic community</li>
-<li>2/1996 <a href="http://web.archive.org/web/19990210183258/http://www.cecer.army.mil/grass/transition.html">USA-CERL no longer support GRASS announcement</a></li>
-<li></li>
+<li>Dec 1997 GRASS GIS 4.2 Baylor University - The first "GRASS Research Group" takes control of GRASS Development from USA-CERL. Extended sites format. This first new <a href="grass42/">GRASS 4.2 release</a> in 4 years adds numerous programs. Popularity increases with academic community</li>
+<li>Feb 1996 <a href="http://web.archive.org/web/19990210183258/http://www.cecer.army.mil/grass/transition.html">USA-CERL no longer support GRASS announcement</a></li>
 <li>1995 <a href="grass_cerl_fp_1995/">internal 5.0fp</a> with floating point raster data implementation. US-CERL withdrawal from GRASS [<a href="ftp://ftp.funet.fi/pub/unix/graphics/packages/grass-incoming/floating_pt/">funet copy</a>]</li>
-<li>1995 GRASS 4.1.5 port to Linux: Yung-Tsung Kang, Michigan State University</li>
+<li>1995 GRASS GIS 4.1.5 port to Linux: Yung-Tsung Kang, Michigan State University</li>
 <li>1993 (Spring) <a href="grass41/">GRASS 4.1 released through Internet</a> - Federal Lab Consortium - Award for Excellence in Technology Transfer</li>
 <li><strong>1982-1991: <a href="grass41/grass1to4history.html">Detailed release description table</a> (GRASS 1 to GRASS 4)</strong></li>
-<li>1991 (July) GRASS 4.0 released through Internet - popularity grows with universities, business and government agencies. Vector Library changed significantly from the library used in GRASS 3.1</li>
+<li>Jul 1991 GRASS GIS 4.0 released through Internet - popularity grows with universities, business and government agencies. Vector Library changed significantly from the library used in GRASS 3.1</li>
 <li>1990 (Winter) <a href="grass32/">GRASS 3.2 released through Internet</a></li>
-<li>1989 GRASS 3.1; First release available on Internet (uxc.cso.uiuc.edu)</li>
-<li>1988 GRASS 3.0; Army R&amp;D Achievement Award (Webster, Goran, Shapiro, Westervelt)</li>
-<li>1987 GRASS 2.0; first issue of <a href="https://grass.osgeo.org/home/history/documents">GRASSClippings 1992</a> + <a href="uploads/grass/history_docs/grassclippings93_7_2_gardels_ogc.pdf">GRASSClippings 1993</a>, <a href="https://grass.osgeo.org/home/history/documents">GRASS video narrated</a> by William Shatner (Captain Kirk of Star Trek)</li>
-<li>1986 GRASS 1.1; receives "Exemplary Systems in Government Award" from URISA</li>
-<li>1985 GRASS 1.0, GRASSnet established [<a href="mailing_lists/grasshopper_1995/">GRASShopper archive 1991-95</a>, <a href="mailing_lists/grassprogrammer1995_1998/">GRASS programmer's archive 1996-1998</a>] - see here for <a href="https://grass.osgeo.org/support/mailing-lists">full archives</a> (1991-today)</li>
+<li>1989 GRASS 3.1: First release available on Internet (uxc.cso.uiuc.edu)</li>
+<li>1988 GRASS 3.0: Army R&amp;D Achievement Award (Webster, Goran, Shapiro, Westervelt)</li>
+<li>1987 GRASS 2.0: first issue of <a href="https://grass.osgeo.org/home/history/documents">GRASSClippings 1992</a> + <a href="uploads/grass/history_docs/grassclippings93_7_2_gardels_ogc.pdf">GRASSClippings 1993</a>, <a href="https://grass.osgeo.org/home/history/documents">GRASS video narrated</a> by William Shatner (Captain Kirk of Star Trek)</li>
+<li>1986 GRASS 1.1: receives "Exemplary Systems in Government Award" from URISA</li>
+<li>1985 GRASS 1.0: GRASSnet established [<a href="mailing_lists/grasshopper_1995/">GRASShopper archive 1991-95</a>, <a href="mailing_lists/grassprogrammer1995_1998/">GRASS programmer's archive 1996-1998</a>] - see here for <a href="https://grass.osgeo.org/support/mailing-lists">full archives</a> (1991-today)</li>
 <li>1984 GRASS (SUN-1 and Masscomp)</li>
-<li>1983 Installation Geographic Information System (IGIS)  (SUN-1 Microcomputer)</li>
+<li>1983 Installation of Geographic Information System (IGIS)  (SUN-1 Microcomputer)</li>
 <li>1982 Fort Hood Information System (FHIS) (Vax 11/780): <a href="uploads/grass/history_docs/fhgis83rep.pdf">Goran, W.D., Dvorak, W.E., Van Warren, L. and Webster, R.D., 1983, Fort Hood Geographic Information System: Pilot System Development and User Instructions, Technical Report N-154, USA Construction Engineering Research Laboratory, Champaign, IL</a></li>
 </ul>
 


### PR DESCRIPTION
I started working on fixing the list of releases (fixed date format, added GIS where missing, change word order, added some bold face here and there), but there's still quite some work to be done. Here a list:
- RC's after 7.2.0 are missing while all other RC are there
- 7.8.1 and 7.8.2 are missing (if this will be a full list, maybe we should also add them here)
- Most of version 6 and earlier releases are not in bold (we could agree here what to put in bold to make it consistent through out the list, I'd suggest only major releases)
- I did not find the figure of the roadmap
- We could split the list in sections, either decades as in History or some other criteria
- Was it called GRASS GIS before version 4?
- 1990 (Winter) GRASS 3.2 released through Internet <-- will links like this one be maintained?