### PR TITLE
fixes download/addons and donation pages + layouts

### DIFF
--- a/content/contribute/donations.md
+++ b/content/contribute/donations.md
@@ -6,7 +6,7 @@ layout: "general"
 
 ## Donations
 
-![Bonn code sprint 2018](/images/grass_sprint2018.jpg)
+<img src="/images/gallery/community/2018_grass_osgeo_codesprint_bonn_fotowall.jpg" width="55%" alt="Bonn code sprint 2018" style="float:right">
 
 ### Why donate
 

--- a/content/download/_index.en.md
+++ b/content/download/_index.en.md
@@ -2,7 +2,7 @@
 title: "Download"
 date: 2019-08-11T11:02:05+05:00
 icon: "fa fa-download"
-description: "Get your free, libre and open source copy of the GRASS GIS software"
+description: "Get your free and open source copy of the GRASS GIS software"
 type : "pages"
 weight: 1
 ---

--- a/content/download/addons.en.md
+++ b/content/download/addons.en.md
@@ -26,6 +26,6 @@ You can also use the command line, for example:
 ### <a name="Power-user"></a>Power users/developers
 
 The AddOns source code is also hosted in <a href="https://github.com/OSGeo/grass-addons" target="_blank"><i class="fa fa-github"></i> Github</a>:
-<p class="command"><a href="https://github.com/OSGeo/grass-addons"> $git clone https://github.com/OSGeo/grass-addons </a></p>
+<p class="command"><a href="https://github.com/OSGeo/grass-addons"> $ git clone https://github.com/OSGeo/grass-addons </a></p>
 
 To manually compile individual extensions see the [compile and install wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install#Addons). 

--- a/content/download/addons.en.md
+++ b/content/download/addons.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Addons"
 date: 2018-12-29T11:02:05+06:00
-description: "Download GRASS GIS user modules"
+description: "Download GRASS GIS addon extension modules"
 weight: 
 categories: [nl]
 layout: "addons"

--- a/content/download/addons.en.md
+++ b/content/download/addons.en.md
@@ -4,10 +4,8 @@ date: 2018-12-29T11:02:05+06:00
 description: "Download GRASS GIS user modules"
 weight: 
 categories: [nl]
-layout: "os"
+layout: "addons"
 ---
-
-Anyone may develop his/her own extensions
 
 #### Quick links
 
@@ -15,16 +13,19 @@ Anyone may develop his/her own extensions
 
 ### <a name="Common-user"></a>Beginner users
 
-We recommend to use the [wxGUI](https://grasswiki.osgeo.org/wiki/WxGUI) [Extension Manager](https://grasswiki.osgeo.org/wiki/WxGUI#Extension_Manager) (`Settings -> Addon extensions -> Install extensions from addons`) to install Addons.
+We recommend to use the [wxGUI](https://grasswiki.osgeo.org/wiki/WxGUI) [Extension Manager](https://grasswiki.osgeo.org/wiki/WxGUI#Extension_Manager) to install Addons.
+In the main menu: `Settings -> Addon extensions -> Install extensions from addons`
 
-![Extension Manager](/images/extension_manager_gui.png "Extension Manager")
+<img src="/images/extension_manager_gui.png" width="80%" alt="Extension Manager">
 
-You can also use the command line
+You can also use the command line, for example:
 
     g.extension extension=r.fuzzy.system
 
 
 ### <a name="Power-user"></a>Power users/developers
 
-The AddOns source code is hosted in [GRASS-AddOns Github repository](https://github.com/osgeo/grass-addons). To manually compile see the [compile and install wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install#Addons). 
+The AddOns source code is also hosted in <a href="https://github.com/OSGeo/grass-addons" target="_blank"><i class="fa fa-github"></i> Github</a>:
+<p class="command"><a href="https://github.com/OSGeo/grass-addons"> $git clone https://github.com/OSGeo/grass-addons </a></p>
 
+To manually compile individual extensions see the [compile and install wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install#Addons). 

--- a/content/download/addons.en.md
+++ b/content/download/addons.en.md
@@ -25,7 +25,7 @@ You can also use the command line, for example:
 
 ### <a name="Power-user"></a>Power users/developers
 
-The AddOns source code is also hosted in <a href="https://github.com/OSGeo/grass-addons" target="_blank"><i class="fa fa-github"></i> Github</a>:
+The Addons source code is also hosted in <a href="https://github.com/OSGeo/grass-addons" target="_blank"><i class="fa fa-github"></i> Github</a>:
 <p class="command"><a href="https://github.com/OSGeo/grass-addons"> $ git clone https://github.com/OSGeo/grass-addons </a></p>
 
-To manually compile individual extensions see the [compile and install wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install#Addons). 
+To manually compile individual addons see the [compile and install wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install#Addons). 

--- a/content/download/data.en.md
+++ b/content/download/data.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Data"
 date: 2018-12-29T11:02:05+06:00
-description: "Download sample data ready for GRASS GIS."
+description: "Download sample data ready for GRASS GIS"
 weight: 
 categories: [nl]
 layout: "data"

--- a/content/download/docker.en.md
+++ b/content/download/docker.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker"
 date: 2018-12-29T11:02:05+06:00
-description: "Download GRASS GIS Docker images."
+description: "Download GRASS GIS Docker images"
 weight: 4
 layout: "os"
 ---

--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Linux"
 date: 2018-12-29T11:02:05+06:00
-description: "Download GRASS GIS packages for your favorite distribution."
+description: "Download GRASS GIS packages for your favorite distribution"
 weight: 1
 layout: "os"
 ---

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Mac"
 date: 2018-12-29T11:02:05+06:00
-description: "Download bundled GRASS GIS binaries for your mac"
+description: "Download bundled GRASS GIS binaries for your Mac"
 weight: 3
 layout: "os"
 ---

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Mac"
 date: 2018-12-29T11:02:05+06:00
-description: "Download bundled GRASS GIS binaries for your mac."
+description: "Download bundled GRASS GIS binaries for your mac"
 weight: 3
 layout: "os"
 ---

--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Windows"
 date: 2018-12-29T11:02:05+06:00
-description: "Download GRASS GIS installers for Windows."
+description: "Download GRASS GIS installers for Windows"
 weight: 2
 layout: "os"
 ---

--- a/themes/grass/layouts/download/addons.html
+++ b/themes/grass/layouts/download/addons.html
@@ -29,7 +29,7 @@
       <div class="col-lg-12">
       <div class="p-5 bg-white">
 	<img src="{{.Site.BaseURL}}/images/logos/grass-Addons.jpg" class="pull-right">
-	<h2 class="page-title">GRASS GIS AddOns</h2>
+	<h2 class="page-title">GRASS GIS Addons</h2>
 	{{ .Content }}
         </div>
       </div>

--- a/themes/grass/layouts/download/addons.html
+++ b/themes/grass/layouts/download/addons.html
@@ -28,8 +28,8 @@
     <div class="row">
       <div class="col-lg-12">
       <div class="p-5 bg-white">
-	<img src="{{.Site.BaseURL}}/images/logos/grass-SampleData.jpg" class="pull-right">
-	<h2 class="page-title">GRASS GIS sample data</h2>
+	<img src="{{.Site.BaseURL}}/images/logos/grass-Addons.jpg" class="pull-right">
+	<h2 class="page-title">GRASS GIS AddOns</h2>
 	{{ .Content }}
         </div>
       </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -55,7 +55,7 @@
 	        {{ if not .Params.categories }}	      
               <div class="section bg-white mb-4">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img src="{{.Site.BaseURL}}/images/grass-{{.Title}}.jpg"></div>
+                  <div class="col-4 text-center"><img src="{{.Site.BaseURL}}/images/logos/grass-{{.Title}}.jpg"></div>
                   <div class="col-6">
 		    <h3 class="mt-2 mb-2">GRASS GIS for {{ .Title }}</h3>
 		    <p>{{ .Description }}</p>
@@ -67,7 +67,7 @@
 	       {{ end }}
                <div class="section bg-white mb-4">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/grasslogo.svg"></div>
+                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="31%"></div>
                   <div class="col-6">
 		    <h3 class="mt-2 mb-2">GRASS GIS AddOns</h3>
 		     <p>Download user contributed GRASS GIS extensions</p>
@@ -78,7 +78,7 @@
 
               <div class="section bg-white mb-4">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/grass-SampleData.jpg"></div>
+                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grass-SampleData.jpg"></div>
                   <div class="col-6">
 		    <h3 class="mt-2 mb-2">GRASS GIS sample data</h3>
 		     <p>Download ready-to-use GRASS GIS sample datasets.</p>
@@ -88,7 +88,7 @@
 		</div>
 	 <div class="section bg-white">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/grasslogo.svg" width="31%"></div>
+                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="31%"></div>
                   <div class="col-6">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
 		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -81,7 +81,7 @@
                   <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grass-SampleData.jpg"></div>
                   <div class="col-6">
 		    <h3 class="mt-2 mb-2">GRASS GIS sample data</h3>
-		     <p>Download ready-to-use GRASS GIS sample datasets.</p>
+		     <p>Download ready-to-use GRASS GIS sample datasets</p>
 		    <a class="btn btn-primary" href="{{.Site.BaseURL}}/download/data">Download</a>
                   </div>
                 </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -92,7 +92,7 @@
                   <div class="col-6">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
 		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>
-		    <p class="command"><a href="https://github.com/OSGeo/grass"> $git clone https://github.com/OSGeo/grass </a></p>
+		    <p class="command"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
I created a specific layout for AddOns to avoid getting the "GRASS GIS for XX" title that makes sense for different OS but not for addons. 
The PR also fixes img sizing (I changed MD style to HTML tags to be able to control size).  
And I also fixed the logos' path for download landing page.