### PR TITLE
try online: wording and typos fixed

### DIFF
--- a/content/learn/tryonline.md
+++ b/content/learn/tryonline.md
@@ -1,6 +1,6 @@
 ---
 title: "Try GRASS GIS online"
-date: 2018-12-29T11:02:05+06:00
+date: 2020-04-13T11:02:05+02:00
 layout: "overview"
 ---
 
@@ -9,10 +9,11 @@ layout: "overview"
 
 [ [**Jupyter notebooks with GRASS GIS on Binder**](#GRASSGISJupyter) | [**GRASS GIS in CoCalc**](#GRASSGISCoCalc) | [**GRASS GIS as rollapp**](#GRASSGISrollapp) ]
 -->
+
 <div class="container">
 <div class="row mt-30">
 <div class="col-lg-8">
-<p>There are several ways to try out <b>GRASS GIS</b> in your browser without installing it. You can throw a glance at <b>GRASS GIS</b> in either <a href="#GRASSGISJupyter">Binder</a><!--, <a href="#GRASSGISCoCalc">CoCalc</a>--> or <a href="#GRASSGISrollApp">rollApp</a>.</p>
+<p>There are several ways to try out <b>GRASS GIS</b> in your browser without even installing it. You can throw a glance at <b>GRASS GIS</b> in either <a href="#GRASSGISJupyter">Binder</a><!--, <a href="#GRASSGISCoCalc">CoCalc</a>--> or <a href="#GRASSGISrollApp">rollApp</a>.</p>
 </div>
 <div class="col-lg-4">
 <img src="../../images/logos/grasslogo.svg" width="25%" alt="GRASS GIS">
@@ -28,25 +29,25 @@ layout: "overview"
 <a href="https://mybinder.org/v2/gh/wenzeslaus/try-grass-in-jupyter/master"><img class="bsh" src="../../images/other/GRASS_mybinder_jupyter_intro.png" width="89%" alt="GRASS GIS Jupyter intro"></a>
 </div>
 <div class="col-lg-6">
-<p>The <b><a href="https://jupyter.org/binder">Binder</a></b> project offers reproducible, sharable, interactive computing environments. From the <b>GRASS GIS</b> community, github repositories are available that can be used to launch a <b>GRASS GIS</b> computing environment with sample data and working examples.
-<p>Through the Binder hub <b>mybinder.org</b>, compute environments defined in the git repositories can be build and started. You can do so by simlpy clicking on one of the two browser images with Juoyter notebooks. The upper image starts a basic introduction to Jupyter Notebooks with <b>GRASS GIS</b>.</p>
-
-  </div>
+<p>The <b><a href="https://jupyter.org/binder">Binder</a></b> project offers reproducible, sharable, interactive computing environments. From the <b>GRASS GIS</b> community, GitHub repositories are available to launch a <b>GRASS GIS</b> computing environment with sample data and working examples.
+<p>Through the Binder hub <b>mybinder.org</b>, compute environments defined in the git repositories can be built and started. You can do so by simply clicking on one of the two browser images with Jupyter notebooks:
+By clicking on the upper screenshot you can start a basic introduction to Jupyter Notebooks with <b>GRASS GIS</b>.</p>
+</div>
 
 <div class="col-lg-6 text-center">
 <a href="https://mybinder.org/v2/gh/wenzeslaus/geospatial-modeling-course-jupyter/master"><img class="bsh" src="../../images/other/GRASS_mybinder_modelling_course.png" width="89%" alt="GRASS GIS Jupyter modelling course" title="GRASS GIS Jupyter modelling course"></a>
 </div>
 <div class="col-lg-6">
-<p>The lower image provides a full, reproducible geospatial modelling course with <b>GRASS GIS</b>. You can start your topic of interest by double clicking one of the notebooks once Jupyter has started.</p>
+<p>By clicking on the lower screenshot you can start a full, reproducible geospatial modelling course with <b>GRASS GIS</b>. You can select your topic of interest by double clicking one of the notebooks once Jupyter has started.</p>
 <div class="alert rounded-0 alert-default">
-<i class="fa fa-arrow-right"></i> Note: Using <b>GRASS GIS</b> in a Jupyter Notebook requires at least basic skills in Python or UNIX command line and does not give access to the full graphical user interface (GUI).
-</div>
-
-  </div>
+<i class="fa fa-arrow-right"></i> Note: Using <b>GRASS GIS</b> in a Jupyter Notebook requires at least basic skills in Python or UNIX command line and does not include the full graphical user interface (GUI).
 </div>
 </div>
 
-<!--
+</div>
+</div>
+
+<!-- commented out since too slow and sample data still missing in CoCalc:
 
 ### Try GRASS GIS in CoCalc
 
@@ -56,15 +57,12 @@ layout: "overview"
 <a href="https://cocalc.com/app?anonymous=x11"><img class="bsh" src="../../images/other/GRASS_cocalc.png" width="89%" alt="Try GRASS GIS in CoCalc" title="Try GRASS GIS in CoCalc"></a>
 </div>
 <div class="col-lg-6">
-<p><b><a href="https://cocalc.com/help?session=default">CoCalc</a></b> offers a comprehensive collection of software environments and libraries. It ships hundrets and thousands of Python and R packages or Julia libraries and provides access to over 200 other executables. <b>GRASS GIS</b> is one of them.</p>
+<p><b><a href="https://cocalc.com/help?session=default">CoCalc</a></b> offers a comprehensive collection of software environments and libraries. It ships hundreds and thousands of Python, R packages or Julia libraries and provides access to over 200 other executables. <b>GRASS GIS</b> is one of them.</p>
 <p>In <b>CoCalc</b>, you can try out the graphical user interface (GUI) of <b>GRASS GIS</b> in a full Linux environment in your browser. Click on the image to get to CoCalc. There you can start <b>GRASS GIS</b> by typing "grass" in the console or via the launch button in the lower left tab.</p>
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-arrow-right"></i> Note: In the free online version, <b>CoCalc</b> offers only minimal compute resources, so please be patient with load times. Also, there is no download in the free tier, so testing possibilities with real data are limited. Build on Ubuntu stable packages, <b>CoCalc</b> neither offers the latest and freshest versions.
 </div>
-
-
-  </div>
-
+</div>
 </div>
 </div>
 -->
@@ -77,13 +75,12 @@ layout: "overview"
 <a href="https://www.rollapp.com/app/grassgis"><img class="bsh" src="../../images/other/GRASS_rollapp.png" width="89%" alt="Try GRASS GIS as rollapp" title="Try GRASS GIS as rollapp"></a>
 </div>
 <div class="col-lg-6">
-<p><b><a href="https://www.rollapp.com">rollApp</a></b> is a cloud platform for native applications. It allows to run over 300 apps directly in the web browser and can be connected to cloud storage like Google Drive, Dropbox, OneDrive, or Box.
-<b>GRASS GIS</b> can be launced as a rollApp. Click on the image to get to the launch site.</p>
+<p><b><a href="https://www.rollapp.com">rollApp</a></b> is a cloud platform for native applications. It allows to run over 300 apps directly in the web browser and can be connected to cloud storages like Google Drive, Dropbox, OneDrive, or Box.
+<b>GRASS GIS</b> can be launched as a rollApp. Click on the screenshot to get to the launch site.</p>
 <div class="alert rounded-0 alert-default">
-<i class="fa fa-arrow-right"></i> Note: You have to register (which is free) in order to launch a rollApp. And as with CoCalc, only minimal compute resources are available in rollApp.
+<i class="fa fa-arrow-right"></i> Note: You have to register (which is free) in order to launch a rollApp. <!--And as with CoCalc, only--> Note that only minimal compute resources are available in rollApp.
 </div>
-
-  </div>
+</div>
 
 </div>
 </div>


### PR DESCRIPTION
Some minor beautification for https://staging.grass.osgeo.org/learn/tryonline/

(see also #59)