### PR TITLE
working on #105 GRASS GIS SVG logo too small

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -856,3 +856,27 @@ nobullets {
 code{
    color: #1d1f21;
 }
+
+@media (max-width: 576px) {
+  .grasslogo{
+     width: 70%;
+  }
+}
+
+@media (min-width: 600px) {
+  .grasslogo {
+    width: 40%;
+  }
+}
+
+@media (min-width: 768px) {
+  .grasslogo {
+    width: 40%;
+  }
+}
+
+@media (min-width: 992px) {
+  .grasslogo {
+    width: 31%;
+  }
+}

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -51,7 +51,7 @@
 	       {{ end }}
                <div class="section bg-white mb-4">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="31%"></div>
+                  <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-6">
 		    <h3 class="mt-2 mb-2">GRASS GIS AddOns</h3>
 		     <p>Download user contributed GRASS GIS extensions</p>
@@ -72,7 +72,7 @@
 		</div>
 	 <div class="section bg-white">
                 <div class="row nm">
-                  <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="31%"></div>
+                  <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-6">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
 		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>


### PR DESCRIPTION
this fix the problem with smartphone but it is not working on tablets, @nbozon could you check it?