### PR TITLE
About section clean-up

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,11 +40,16 @@ greyColorDark = "#A0A0A0"
 
     # navigation
     [Languages.en.menu]
-    
-      [[Languages.en.menu.main]]
-        weight = 1
-        name = "Download"
-        url = "/download"
+
+    [[Languages.en.menu.main]]
+      weight = 1
+      name = "News"
+      URL = "/news"
+
+    [[Languages.en.menu.main]]
+      weight = 2
+      name = "Download"
+      url = "/download"
 
 	[[Languages.en.menu.main]]
           parent = "Download"
@@ -70,7 +75,7 @@ greyColorDark = "#A0A0A0"
           URL = "/download/docker"
           weight = 4
 
-        [[Languages.en.menu.main]]
+    [[Languages.en.menu.main]]
           parent = "Download"
           name = "Addons"
           URL = "/download/addons"
@@ -83,7 +88,7 @@ greyColorDark = "#A0A0A0"
           weight = 6
         
       [[Languages.en.menu.main]]
-        weight = 2
+        weight = 3
         name = "Learn"
         url = "/learn"
 
@@ -125,7 +130,7 @@ greyColorDark = "#A0A0A0"
 
     
       [[Languages.en.menu.main]]
-        weight = 3
+        weight = 4
         name = "Contribute"
         url = "/contribute"
         hasChildren = true
@@ -156,15 +161,15 @@ greyColorDark = "#A0A0A0"
 
 
       [[Languages.en.menu.main]]
-        weight = 4
+        weight = 5
         name = "About"
         url = "/about"
         hasChildren = true
-	
+
           [[Languages.en.menu.main]]
           parent = "About"
-          name = "News"
-          URL = "/news"
+          name = "License"
+          URL = "/about/license"
           weight = 1
 
           [[Languages.en.menu.main]]
@@ -175,15 +180,15 @@ greyColorDark = "#A0A0A0"
 
           [[Languages.en.menu.main]]
           parent = "About"
-          name = "Brand"
-          URL = "/about/brand"
-          weight = 4
-
-          [[Languages.en.menu.main]]
-          parent = "About"
           name = "History"
           URL = "/about/history"
           weight = 3
+
+          [[Languages.en.menu.main]]
+          parent = "About"
+          name = "Brand"
+          URL = "/about/brand"
+          weight = 4
 
           [[Languages.en.menu.main]]
           parent = "About"

--- a/content/about/brand.md
+++ b/content/about/brand.md
@@ -155,18 +155,3 @@ grey-color-light-bg mb-2"></div>
 </ul>
 </div>
 
-### Citing GRASS
-
-<p> Please use the following BibTeX entry for citing the <b>GRASS GIS</b> software in scientific work written in LaTeX.</p>
-
-<pre>
-<code class="hljs tex">
-@Manual{GRASS_GIS_software,
-title = {Geographic Resources Analysis Support System (GRASS GIS) Software},
-author = {{GRASS Development Team}},
-organization = {Open Source Geospatial Foundation},
-address = {USA},
-year = {2020},
-url = {https://grass.osgeo.org},
-}
-</code>

--- a/content/about/license.md
+++ b/content/about/license.md
@@ -4,30 +4,62 @@ date: 2018-12-29T11:02:05+06:00
 layout: "overview"
 ---
 
-## Copyright and License Information
+### Copyright and License Information
 
-Geographic Resources Analysis Support System (GRASS) is Copyright, 1999-2019 GRASS Development Team, and licensed under the terms of the GNU General Public License (GPL). This includes all software, documentation, and associated materials.
+Geographic Resources Analysis Support System (GRASS) is Copyright, 
+1999-2020 GRASS Development Team, and licensed under the terms of 
+the GNU General Public License (GPL). This includes all software, 
+documentation, and associated materials.
 
-GRASS GIS is free and open source software, you can redistribute it and/or modify it under the terms of the [GNU General Public License](http://www.gnu.org/licenses/sgpl-3.0.html) as published by the [Free Software Foundation](https://www.fsf.org/).
+GRASS GIS is free and open source software, you can redistribute it 
+and/or modify it under the terms of the 
+[GNU General Public License](http://www.gnu.org/licenses/#GPL) (>=v2)
+as published by the [Free Software Foundation](https://www.fsf.org/).
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [GNU General Public License](http://www.gnu.org/licenses/gpl-3.0.html) for more details.
+This program is distributed in the hope that it will be useful, 
+but *WITHOUT ANY WARRANTY*; without even the implied warranty 
+of *MERCHANTABILITY* or *FITNESS FOR A PARTICULAR PURPOSE*. 
+See the [GNU General Public License](http://www.gnu.org/licenses/#GPL) 
+for further details.
 
-If you are not sure about the differences between public domain software, Free Software and proprietary products, have a look at this webpage: [Categories of Free and Non-Free Software](http://www.gnu.org/philosophy/categories.html).
+If you are not sure about the differences between public domain
+software, Free Software and proprietary products, have a look 
+at this graphic describing [categories of Free and Non-Free Software](http://www.gnu.org/philosophy/categories.html).
 
-Questions regarding details of this policy can be directed to this [email address](grass-web@lists.osgeo.org).
+Questions regarding details of this policy can be directed to 
+this [email address](grass-web@lists.osgeo.org).
 
 See also the [Frequently Asked Questions about the GNU GPL](http://www.gnu.org/licenses/gpl-faq.html).
 
-# Citing GRASS GIS Software
-Please cite GRASS when using the software in your work. Here are some choices depending on the version used:
-- GRASS Development Team, 2019. Geographic Resources Analysis Support System (GRASS) Software, Version 7.6. Open Source Geospatial 
-Foundation. https://grass.osgeo.org
-- GRASS Development Team, 2018. Geographic Resources Analysis Support System (GRASS) Software, Version 7.4. Open Source Geospatial 
-Foundation. https://grass.osgeo.org
+### Citing GRASS GIS Software
 
+Please cite GRASS when using the software in your work. Here are some choices
+depending on the version used:
 
+- GRASS Development Team, 2019. Geographic Resources Analysis Support System (GRASS)
+Software, Version 7.8. Open Source Geospatial Foundation. https://grass.osgeo.org
 
+- GRASS Development Team, 2019. Geographic Resources Analysis Support System (GRASS) 
+Software, Version 7.6. Open Source Geospatial Foundation. https://grass.osgeo.org
 
-- GRASS Development Team, 2015. Geographic Resources Analysis Support System (GRASS) Programmer's Manual. Open Source Geospatial Foundation. Electronic document: http://grass.osgeo.org/programming7/
+- GRASS Development Team, 2020. Geographic Resources Analysis Support System (GRASS) 
+Programmer's Manual. Open Source Geospatial Foundation. Electronic document: 
+https://grass.osgeo.org/programming7/
 
-For more options, see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository)
+<p> Use the following BibTeX entry for citing the <b>GRASS GIS</b> software in 
+scientific work written in LaTeX.</p>
+
+<pre>
+<code class="hljs tex">
+@Manual{GRASS_GIS_software,
+    title = {Geographic Resources Analysis Support System (GRASS GIS) Software},
+    author = {{GRASS Development Team}},
+    organization = {Open Source Geospatial Foundation},
+    address = {USA},
+    year = {2020},
+    url = {https://grass.osgeo.org}
+}
+</code>
+</pre>
+
+For more options see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository).


### PR DESCRIPTION
This PR

- moves `News` outside `About` and places it before `Download` in the upper menu bar,
- reorder items within `About` menu,
- adds License into `About` menu,
- beautifies `License` and, 
- moves the bibtex citation from `Brand` into `License`

addressing issues #32, #121, and partially #90.

**Remaining points to be solved:**
- side menu in License shows links to all files in the folder (as the issue solved for About in d4c0d5cabf7ef5508c7a190e5df618e98a14f94f). Can we fix it here too or maybe change the layout, @nbozon ?
- bottom of the page shows "updated + date from the header of the file" that any other page displays