### PR TITLE
clean up download linux page

### DIFF
--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -8,56 +8,54 @@ layout: "os"
 
 #### Quick links
 
-[ [**GRASS GIS 7.8.2 (new stable)**](#GRASS-GIS-new-stable) | [**GRASS 7.6.1 (old stable)**](#GRASS-GIS-old-stable) | [**GRASS 7.9 devel**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.2 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 7.9 devel**](#GRASS-GIS-devel) ]
 
 <hr>
 
-### <a name="GRASS-GIS-new-stable"></a> GRASS GIS 7.8.2 (new stable)
+Install <tt>grass</tt> package on your Linux distribution. See also
+[Repology](https://repology.org/project/grass/versions) for extended
+list of GRASS GIS packages.
+
+*  [Arch Linux](https://aur.archlinux.org/packages/grass/)
+*  [Debian](https://packages.debian.org/grass)
+*  [Mageia](https://madb.mageia.org/package/show/name/grass/)
+*  [openSUSE](https://build.opensuse.org/package/show/Application:Geo/grass)
+*  [Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable/+packages?field.name_filter=grass)  (ubuntugis-unstable)
+
+### <a name="GRASS-GIS-current"></a> GRASS GIS 7.8.2 (current)
 
 <div class="alert rounded-0 alert-success">
-<i class="fa fa-info-circle"></i> <u>New stable release</u>, see <a href="(https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78 ">GRASS GIS 7.8.2 new features</a> and <a href="(https://trac.osgeo.org/grass/wiki/Release/7.8.2-News ">GRASS GIS 7.8.2 announcement</a> for more information.</div>
+<i class="fa fa-info-circle"></i> <u>Current stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78">GRASS GIS 7.8 new features</a> and <a href="https://trac.osgeo.org/grass/wiki/Release/7.8.2-News">GRASS GIS 7.8.2 announcement</a> for more information.</div>
 
 *  [Generic 64bit](https://grass.osgeo.org/grass78/binary/linux/snapshot) (weekly binary snapshot)
-*  [Arch Linux](https://aur.archlinux.org/packages/grass/)
-*  [Debian](https://packages.debian.org/grass)
 *  [EPEL7](https://copr.fedorainfracloud.org/coprs/neteler/grass78/) (RHEL7/Centos7/Scientific Linux7)
 *  [Fedora](https://copr.fedorainfracloud.org/coprs/neteler/grass78/)
-*  [Mageia](https://madb.mageia.org/package/show/name/grass/)
-*  [openSUSE Debian](https://build.opensuse.org/package/show/Application:Geo/grass)
-*  [Ubuntu ](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)  (ubuntugis-unstable)
-*  [Repology](https://repology.org/project/grass/versions) (extended list of GRASS GIS packages)
 
 <hr>
 
-### <a name="GRASS-GIS-old-stable"></a> GRASS GIS 7.6.1 (old stable)
+### <a name="GRASS-GIS-old"></a> GRASS GIS 7.6.1 (old)
 
 <div class="alert rounded-0 alert-warning">
-<i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76">GRASS GIS 7.6.1 new features</a> and  <a href="https://trac.osgeo.org/grass/wiki/Release/7.6.1-News">GRASS GIS 7.6.1 announcement</a> for more information.
+<i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76">GRASS GIS 7.6 new features</a> and  <a href="https://trac.osgeo.org/grass/wiki/Release/7.6.1-News">GRASS GIS 7.6.1 announcement</a> for more information.
 </div>
 
-*  [Generic 64bit](https://grass.osgeo.org/grass78/binary/linux/snapshot) (weekly binary snapshot)
-*  [Arch Linux](https://aur.archlinux.org/packages/grass/)
-*  [Debian](https://packages.debian.org/grass)
-*  [EPEL7](https://copr.fedorainfracloud.org/coprs/neteler/grass78/) (RHEL7/Centos7/Scientific Linux7)
-*  [Fedora](https://copr.fedorainfracloud.org/coprs/neteler/grass78/)
-*  [Mageia](https://madb.mageia.org/package/show/name/grass/)
-*  [openSUSE Debian](https://build.opensuse.org/package/show/Application:Geo/grass)
-*  [Ubuntu ](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)  (ubuntugis-unstable)
-*  [Repology](https://repology.org/project/grass/versions) (extended list of GRASS GIS packages)
+*  [Generic 64bit](https://grass.osgeo.org/grass76/binary/linux/snapshot) (weekly binary snapshot)
+*  [EPEL7](https://copr.fedorainfracloud.org/coprs/neteler/grass76/) (RHEL7/Centos7/Scientific Linux7)
+*  [Fedora](https://copr.fedorainfracloud.org/coprs/neteler/grass76/)
 
 <hr>
 
-### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 devel (unstable)
+### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (development)
 
 <div class="alert rounded-0 alert-info">
-<i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS GIS</b> version.
+<i class="fa fa-info-circle"></i> Active <u>development</u>, <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
 *  [Generic 64bit](https://grass.osgeo.org/grass79/binary/linux/snapshot/) (weekly binary snapshot)
-*  [Ubuntu ](https://launchpad.net/~grass/+archive/ubuntu/grass-devel)  (ubuntugis-unstable)
 
-<pre><code class="shell">sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-sudo add-apt-repository ppa:grass/grass-devel
-sudo apt-get update
-sudo apt-get install grass-daily</code></pre>
+<!-- *  [Ubuntu ](https://launchpad.net/~grass/+archive/ubuntu/grass-devel)  (ubuntugis-unstable) -->
 
+<!-- <pre><code class="shell">sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -->
+<!-- sudo add-apt-repository ppa:grass/grass-devel -->
+<!-- sudo apt-get update -->
+<!-- sudo apt-get install grass-daily</code></pre> -->

--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -8,7 +8,7 @@ layout: "os"
 
 #### Quick links
 
-[ [**GRASS GIS 7.8.2 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 7.9 devel**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.2 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 7.9 (devel)**](#GRASS-GIS-devel) ]
 
 <hr>
 
@@ -45,7 +45,7 @@ list of GRASS GIS packages.
 
 <hr>
 
-### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (development)
+### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (devel)
 
 <div class="alert rounded-0 alert-info">
 <i class="fa fa-info-circle"></i> Active <u>development</u>, <u>experimental</u> <b>GRASS GIS</b> version.


### PR DESCRIPTION
* new stable -> current
* comment-out broken stuff (grass-daily)
* move generic links to upper part

![Screenshot_2020-05-03 Linux(1)](https://user-images.githubusercontent.com/5683186/80914741-dabc6780-8d4d-11ea-927c-a4dd58aa7c88.png)

