### PR TITLE
fix for #70

### DIFF
--- a/content/learn/newcomers.md
+++ b/content/learn/newcomers.md
@@ -50,17 +50,20 @@ by Vaclav Petras & the NCSU GeoForAll Lab.
 a kind of **from zero to hero** GRASS GIS course by Martin Landa, Luca Delucchi
 and Stefan Blumentrath.
 * For more [specific topics](https://grass.osgeo.org/grass-stable/manuals/graphical_index.html) 
-(e.g. raster data, vector data, database, etc), you should also read the 
+(e.g. raster data, vector data, time series, database, etc), you should also read the 
 relevant topic introductions as they will provide you with helpful information 
 about how these specific domains are handled in GRASS GIS.
 
 
 #### Videos
 
+There are many sources of videos with presentations about GRASS GIS and
+tutorials on different topics online.
+For example, you can just search YouTube for the [GRASS GIS videos](https://www.youtube.com/results?search_query=grass+gis) 
 <i class="fa fa-video-camera fa-5x" style="float:left;padding-right:30px"></i>
-
-You can just search YouTube for the [GRASS GIS videos](https://www.youtube.com/results?search_query=grass+gis) 
-available there. However, here are pointers to some videos that might be 
+available there or check different [FOSS4G](https://foss4g.org/) events in the last years 
+(have a look at FOSS4G Bucharest 2019 [videos](https://media.ccc.de/c/foss4g2019)). 
+Here are, however, some pointers to selected videos that might be 
 particularly useful for you as a beginner:
 
 * An [introduction to GRASS GIS](https://www.youtube.com/watch?v=wT5SbZtZ12E) 


### PR DESCRIPTION
I just added a couple more sentences to `First time users > Videos` section so the film camera appears surrounded by text as suggested by @lucadelu in https://github.com/OSGeo/grass-website/issues/70#issuecomment-623186769

Looks like this now:
![image](https://user-images.githubusercontent.com/20075188/81504002-373bfb80-92e7-11ea-8675-290a1fcd5af9.png)
