### PR TITLE
Use unified width for images in book tables

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -296,6 +296,7 @@ table tr td {
 }
 table img {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07) !important;
+  max-width: 10vw;
 }
 .github {
   background: var(--grass-color-light);


### PR DESCRIPTION
The size of images on learn/books page is driven by the image size instead of the layout. I'm using `max-width: 10vw;` to unify (limit) their widths.

For now I added `max-width` to general `table img`, but that does not seem like a good solution. Please comment.
