### PR TITLE
avoid absolute URLs to server

### DIFF
--- a/content/contribute/_index.en.md
+++ b/content/contribute/_index.en.md
@@ -54,7 +54,7 @@ Developing your own modules? Great!
 
 Please upload your add-ons to the **GRASS GIS Addons repository**. In this way, they become available to the community
 through the extension manager (g.extension or graphical user interface). 
-Here is the full list of [existing addons](https://grass.osgeo.org/grass7/manuals/addons/) to get inspired.
+Here is the full list of [existing addons](/grass7/manuals/addons/) to get inspired.
 
 Further details about how to gain access to our [GitHub Addons repository](https://github.com/OSGeo/grass-addons/) can be
 found in [this document](https://trac.osgeo.org/grass/wiki/HowToContribute#WriteaccesstotheGRASSaddonsrepository).

--- a/content/download/addons.en.md
+++ b/content/download/addons.en.md
@@ -9,7 +9,7 @@ layout: "addons"
 
 #### Quick links
 
-[ [Overview of addons](https://grass.osgeo.org/grass7/manuals/addons/) | [**Beginner users**](#Common-user) | [**Power users/developers**](#Power-user) ]
+[ [Overview of addons](/grass7/manuals/addons/) | [**Beginner users**](#Common-user) | [**Power users/developers**](#Power-user) ]
 
 ### <a name="Common-user"></a>Beginner users
 

--- a/content/download/data.en.md
+++ b/content/download/data.en.md
@@ -31,7 +31,7 @@ layout: "data"
 
 This dataset is a modern package of geospatial data from the state of North Carolina, USA. It offers raster, vector, LiDAR and satellite data.
 Most of the examples in the module <a href="../../learn/manuals">manuals</a> are written with this dataset. Furthermore, the
-<a href="https://grass.osgeo.org/grass-devel/manuals/libpython/gunittest_testing.html">testsuite</a> operates with this dataset.
+<a href="/grass-devel/manuals/libpython/gunittest_testing.html">testsuite</a> operates with this dataset.
 The description, list of maps, and a quick usage tutorial are available <a href="https://www.grassbook.org/wp-content/uploads/grasslocations/nc_spm_08_contents.html">here</a>.
 
 The North Carolina dataset can be downloaded in two versions:
@@ -42,9 +42,9 @@ The North Carolina dataset can be downloaded in two versions:
   <a href="http://fatra.cnr.ncsu.edu/data/nc_spm_full_v2alpha2.tar.gz" class="inl btn btn-secondary">Download TAR.GZ (159 MB)</a>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip" target="_blank"> North Carolina basic dataset </a></span>
-  <a href="https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip" class="inl btn btn-primary" target="_blank">Download ZIP  (50 MB)</a>
-  <a href="https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.tar.gz" class="inl btn btn-secondary">Download TAR.GZ  (50 MB)</a>
+  <span class="mwl"><a href="/sampledata/north_carolina/nc_basic_spm_grass7.zip" target="_blank"> North Carolina basic dataset </a></span>
+  <a href="/sampledata/north_carolina/nc_basic_spm_grass7.zip" class="inl btn btn-primary" target="_blank">Download ZIP  (50 MB)</a>
+  <a href="/sampledata/north_carolina/nc_basic_spm_grass7.tar.gz" class="inl btn btn-secondary">Download TAR.GZ  (50 MB)</a>
   </li>
 </ul>
 
@@ -55,13 +55,13 @@ The North Carolina dataset can be downloaded in two versions:
 
 This is the classical GRASS GIS dataset from the 1980th covering a part of
 Spearfish, South Dakota, USA, with raster, vector and point data. For more information on the dataset see
-the short <a href="https://grass.osgeo.org/uploads/grass/sampledata/spearDB.pdf">documentation</a> and
-<a href="https://grass.osgeo.org/uploads/grass/sampledata/spearfish_docs_1979_p163to171.tar.gz">soil data documentation</a> (with
-<a href="https://grass.osgeo.org/uploads/grass/sampledata/soils_legend.txt">legend</a> for soils map). 
+the short <a href="/uploads/grass/sampledata/spearDB.pdf">documentation</a> and
+<a href="/uploads/grass/sampledata/spearfish_docs_1979_p163to171.tar.gz">soil data documentation</a> (with
+<a href="/uploads/grass/sampledata/soils_legend.txt">legend</a> for soils map).
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/sampledata/spearfish_grass70data-0.3.tar.gz" target="_blank"> Spearfish dataset </a></span>
-  <a href="https://grass.osgeo.org/sampledata/spearfish_grass70data-0.3.tar.gz" class="inl btn btn-primary" target="_blank">Download TAR.GZ (20 MB)</a>
+  <span class="mwl"><a href="/sampledata/spearfish_grass70data-0.3.tar.gz" target="_blank"> Spearfish dataset </a></span>
+  <a href="/sampledata/spearfish_grass70data-0.3.tar.gz" class="inl btn btn-primary" target="_blank">Download TAR.GZ (20 MB)</a>
   </li>
 </ul>
 
@@ -79,29 +79,29 @@ the short <a href="https://grass.osgeo.org/uploads/grass/sampledata/spearDB.pdf"
   <p>Selected maps in common GIS formats (SHAPE, KML, GeoTIFF) including RGB orthophoto</p>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass-stable/manuals/" target="_blank"> LiDAR </a></span>
-  <a href="https://grass.osgeo.org/sampledata/north_carolina/lidar_raleigh_nc_spm_height_feet_las.zip" class="inl btn btn-primary" target="_blank">LAS (21 MB)</a>
-  <a href="https://grass.osgeo.org/sampledata/north_carolina/lidar_raleigh_nc_spm_height_feet.laz" class="inl btn btn-primary">LAZ (6 MB)</a>
+  <span class="mwl"><a href="/grass-stable/manuals/" target="_blank"> LiDAR </a></span>
+  <a href="/sampledata/north_carolina/lidar_raleigh_nc_spm_height_feet_las.zip" class="inl btn btn-primary" target="_blank">LAS (21 MB)</a>
+  <a href="/sampledata/north_carolina/lidar_raleigh_nc_spm_height_feet.laz" class="inl btn btn-primary">LAZ (6 MB)</a>
   <p>Extra Raleigh LiDAR dataset (note: height in feet):  multi-return</p>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass-stable/manuals/ " target="_blank"> Climate </a></span>
-  <a href="https://grass.osgeo.org/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (690 MB)</a>
+  <span class="mwl"><a href="/grass-stable/manuals/ " target="_blank"> Climate </a></span>
+  <a href="/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (690 MB)</a>
   <p>North Carolina location with climatic data time series (nc_climate_spm_2000_2012) - see also the related <a href="http://ncsu-geoforall-lab.github.io/grass-temporal-workshop/">tutorial</a></p>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass-stable/manuals/ " target="_blank"> Time series </a></span>
-  <a href="https://grass.osgeo.org/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (2 MB)</a>
+  <span class="mwl"><a href="/grass-stable/manuals/ " target="_blank"> Time series </a></span>
+  <a href="/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (2 MB)</a>
   <p>Extra time series of MODIS Land Surface Temperature (mapset to unzip in NC location): MODIS LST time series</p>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass-stable/manuals/ " target="_blank"> Projection </a></span>
-  <a href="https://grass.osgeo.org/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (2 MB)</a>
+  <span class="mwl"><a href="/grass-stable/manuals/ " target="_blank"> Projection </a></span>
+  <a href="/grass-stable/manuals/" class="inl btn btn-primary" target="_blank">Download ZIP (2 MB)</a>
   <p>NAD83(HARN) / North Carolina, EPSG 3358)</p>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/sampledata/slovakia3d_readme.txt" target="_blank"> 3D / voxel </a></span>
-  <a href="https://grass.osgeo.org/sampledata/slovakia3d_grass7.tar.gz" class="inl btn btn-primary" target="_blank">Download ZIP (8.9 MB)</a>
+  <span class="mwl"><a href="/sampledata/slovakia3d_readme.txt" target="_blank"> 3D / voxel </a></span>
+  <a href="/sampledata/slovakia3d_grass7.tar.gz" class="inl btn btn-primary" target="_blank">Download ZIP (8.9 MB)</a>
   <p>Complete Slovakia 3D precipitation location: Slovakia 3D precipitation voxel dataset</p>
 
   </li>

--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -27,7 +27,7 @@ list of GRASS GIS packages.
 <div class="alert rounded-0 alert-success">
 <i class="fa fa-info-circle"></i> <u>Current stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78">GRASS GIS 7.8 new features</a> and <a href="https://trac.osgeo.org/grass/wiki/Release/7.8.2-News">GRASS GIS 7.8.2 announcement</a> for more information.</div>
 
-*  [Generic 64bit](https://grass.osgeo.org/grass78/binary/linux/snapshot) (weekly binary snapshot)
+*  [Generic 64bit](/grass78/binary/linux/snapshot) (weekly binary snapshot)
 *  [EPEL7](https://copr.fedorainfracloud.org/coprs/neteler/grass78/) (RHEL7/Centos7/Scientific Linux7)
 *  [Fedora](https://copr.fedorainfracloud.org/coprs/neteler/grass78/)
 
@@ -39,7 +39,7 @@ list of GRASS GIS packages.
 <i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76">GRASS GIS 7.6 new features</a> and  <a href="https://trac.osgeo.org/grass/wiki/Release/7.6.1-News">GRASS GIS 7.6.1 announcement</a> for more information.
 </div>
 
-*  [Generic 64bit](https://grass.osgeo.org/grass76/binary/linux/snapshot) (weekly binary snapshot)
+*  [Generic 64bit](/grass76/binary/linux/snapshot) (weekly binary snapshot)
 *  [EPEL7](https://copr.fedorainfracloud.org/coprs/neteler/grass76/) (RHEL7/Centos7/Scientific Linux7)
 *  [Fedora](https://copr.fedorainfracloud.org/coprs/neteler/grass76/)
 
@@ -51,7 +51,7 @@ list of GRASS GIS packages.
 <i class="fa fa-info-circle"></i> Active <u>development</u>, <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
-*  [Generic 64bit](https://grass.osgeo.org/grass79/binary/linux/snapshot/) (weekly binary snapshot)
+*  [Generic 64bit](/grass79/binary/linux/snapshot/) (weekly binary snapshot)
 
 <!-- *  [Ubuntu ](https://launchpad.net/~grass/+archive/ubuntu/grass-devel)  (ubuntugis-unstable) -->
 

--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -24,8 +24,8 @@ layout: "os"
 <div class="alert rounded-0 alert-success">
 <i class="fa fa-info-circle"></i> <u>New stable release</u>, see <a href="(https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78 ">GRASS GIS 7.8.2 new features</a> and <a href="(https://trac.osgeo.org/grass/wiki/Release/7.8.2-News ">GRASS GIS 7.8.2 announcement</a> for more information.</div>
 
-*  [<i class="fa fa-download"></i> Download 64bit](https://grass.osgeo.org/grass78/binary/mswindows/native/x86_64/WinGRASS-7.8.2-1-Setup-x86_64.exe) 
-*  [<i class="fa fa-download"></i> Download 32bit](https://grass.osgeo.org/grass78/binary/mswindows/native/x86/WinGRASS-7.8.2-1-Setup-x86.exe) 
+*  [<i class="fa fa-download"></i> Download 64bit](/grass78/binary/mswindows/native/x86_64/WinGRASS-7.8.2-1-Setup-x86_64.exe)
+*  [<i class="fa fa-download"></i> Download 32bit](/grass78/binary/mswindows/native/x86/WinGRASS-7.8.2-1-Setup-x86.exe)
 
 <hr>
 
@@ -36,8 +36,8 @@ layout: "os"
 </div>
 
 
-*  [<i class="fa fa-download"></i> Download 64bit](https://grass.osgeo.org/grass76/binary/mswindows/native/x86_64/WinGRASS-7.6.1-1-Setup-x86_64.exe) 
-*  [<i class="fa fa-download"></i> Download 32bit](https://grass.osgeo.org/grass76/binary/mswindows/native/x86/WinGRASS-7.6.1-1-Setup-x86.exe) 
+*  [<i class="fa fa-download"></i> Download 64bit](/grass76/binary/mswindows/native/x86_64/WinGRASS-7.6.1-1-Setup-x86_64.exe)
+*  [<i class="fa fa-download"></i> Download 32bit](/grass76/binary/mswindows/native/x86/WinGRASS-7.6.1-1-Setup-x86.exe)
 
 <hr>
 

--- a/content/learn/manuals.md
+++ b/content/learn/manuals.md
@@ -8,34 +8,34 @@ layout: "manuals"
 
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass79/manuals/index.html " target="_blank"> GRASS GIS 7.9 (devel) </a></span>
-  <a href="https://grass.osgeo.org/grass79/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass79/manuals/index.html " target="_blank"> GRASS GIS 7.9 (devel) </a></span>
+  <a href="/grass79/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass78/manuals/index.html " target="_blank"> GRASS GIS 7.8 (stable) </a></span>
-  <a href="https://grass.osgeo.org/grass78/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass78/manuals/index.html " target="_blank"> GRASS GIS 7.8 (stable) </a></span>
+  <a href="/grass78/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass76/manuals/index.html " target="_blank"> GRASS GIS 7.6 (old stable) </a></span>
-  <a href="https://grass.osgeo.org/grass76/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass76/manuals/index.html " target="_blank"> GRASS GIS 7.6 (old stable) </a></span>
+  <a href="/grass76/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
 <!--
  <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass74/manuals/index.html " target="_blank"> GRASS GIS 7.4 (stable) </a></span>
-  <a href="https://grass.osgeo.org/grass74/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass74/manuals/index.html " target="_blank"> GRASS GIS 7.4 (stable) </a></span>
+  <a href="/grass74/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass72/manuals/index.html " target="_blank"> GRASS GIS 7.2 (stable) </a></span>
-  <a href="https://grass.osgeo.org/grass72/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass72/manuals/index.html " target="_blank"> GRASS GIS 7.2 (stable) </a></span>
+  <a href="/grass72/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass70/manuals/index.html " target="_blank"> GRASS GIS 7.0 (stable) </a></span>
-  <a href="https://grass.osgeo.org/grass70/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass70/manuals/index.html " target="_blank"> GRASS GIS 7.0 (stable) </a></span>
+  <a href="/grass70/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
 -->
      <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass64/manuals/index.html " target="_blank"> GRASS GIS 6.4 (very old stable) </a></span>
-  <a href="https://grass.osgeo.org/grass64/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass64/manuals/index.html " target="_blank"> GRASS GIS 6.4 (very old stable) </a></span>
+  <a href="/grass64/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="#" class="inl btn btn-secondary">Download ZIP</a>
   </li>
 </ul>
 
@@ -43,13 +43,13 @@ layout: "manuals"
 
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass7/manuals/addons/ " target="_blank"> GRASS GIS 7 addons </a></span>
-  <a href="https://grass.osgeo.org/grass7/manuals/addons/" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl"><a href="/grass7/manuals/addons/ " target="_blank"> GRASS GIS 7 addons </a></span>
+  <a href="/grass7/manuals/addons/" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
 <!-- outdated
 <li>
-  <span class="mwl"><a href="https://grass.osgeo.org/grass6/manuals/addons/ " target="_blank"> GRASS GIS 6 addons (unsupported) </a></span>
-  <a href="https://grass.osgeo.org/grass6/manuals/addons/" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl"><a href="/grass6/manuals/addons/ " target="_blank"> GRASS GIS 6 addons (unsupported) </a></span>
+  <a href="/grass6/manuals/addons/" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
 -->
 </ul>
@@ -58,8 +58,8 @@ layout: "manuals"
 
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl-l"><a href="https://grass.osgeo.org/programming7/ " target="_blank">GRASS GIS 7 Programmer's Manual</a></span>
-  <a href="https://grass.osgeo.org/programming7/" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="/programming7/ " target="_blank">GRASS GIS 7 Programmer's Manual</a></span>
+  <a href="/programming7/" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
   <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/master/doc/vector/v.example " target="_blank"> GRASS GIS 7 Example Vector Module in C</a></span>
@@ -70,8 +70,8 @@ layout: "manuals"
   <a href="https://github.com/OSGeo/grass/tree/master/doc/raster/r.example" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://grass.osgeo.org/grass79/manuals/libpython/index.html " target="_blank"> GRASS GIS 7 Python Library Manual</a></span>
-  <a href="https://grass.osgeo.org/grass79/manuals/libpython/index.html" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="/grass79/manuals/libpython/index.html " target="_blank"> GRASS GIS 7 Python Library Manual</a></span>
+  <a href="/grass79/manuals/libpython/index.html" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
   <span class="mwl-l"><a href="https://gitlab.com/vpetras/r.example.plus " target="_blank"> GRASS GIS 7 Example Python Module</a></span>
@@ -82,7 +82,7 @@ layout: "manuals"
   <a href="https://github.com/OSGeo/grass/tree/master/doc/gui/wxpython/example" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://grass.osgeo.org/grass79/manuals/parser_standard_options.html " target="_blank"> GRASS GIS 7 Parser Standard Options</a></span>
-  <a href="https://grass.osgeo.org/grass79/manuals/parser_standard_options.html" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="/grass79/manuals/parser_standard_options.html " target="_blank"> GRASS GIS 7 Parser Standard Options</a></span>
+  <a href="/grass79/manuals/parser_standard_options.html" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
 </ul>

--- a/content/learn/newcomers.md
+++ b/content/learn/newcomers.md
@@ -40,7 +40,7 @@ resources that might help you get started:
 
 <img src="/images/gallery/gui/grass75_ndvi_rgb_rio_cuarto.png" width="45%" alt="" style="float:right;padding-left:10px">
 
-* The [Quickstart](https://grass.osgeo.org/grass-stable/manuals/helptext.html) 
+* The [Quickstart](/grass-stable/manuals/helptext.html) 
 in the manual pages.
 * The [Quick GUI tutorial](https://grasswiki.osgeo.org/wiki/Quick_wxGUI_tutorial).
 * An [introductory workshop](http://ncsu-geoforall-lab.github.io/grass-intro-workshop/) 
@@ -49,7 +49,7 @@ by Vaclav Petras & the NCSU GeoForAll Lab.
 * [Advanced Geospatial Analysis for Earth Observation and Time Series data](https://training.gismentors.eu/grass-gis-irsae-winter-course-2018/) 
 a kind of **from zero to hero** GRASS GIS course by Martin Landa, Luca Delucchi
 and Stefan Blumentrath.
-* For more [specific topics](https://grass.osgeo.org/grass-stable/manuals/graphical_index.html) 
+* For more [specific topics](/grass-stable/manuals/graphical_index.html) 
 (e.g. raster data, vector data, time series, database, etc), you should also read the 
 relevant topic introductions as they will provide you with helpful information 
 about how these specific domains are handled in GRASS GIS.

--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -68,7 +68,7 @@ the existent ones.</p>
 both an intuitive graphical user interface (GUI) and a command line 
 syntax useful for automation and production.</p>
 <p><b>GRASS GIS</b> contains over 
-<b><a href="https://grass.osgeo.org/grass-stable/manuals/full_index.html" target="_blank">500 modules</a></b> 
+<b><a href="/grass-stable/manuals/full_index.html" target="_blank">500 modules</a></b>
 to process and render geographic data. The software allows to manipulate
 a variety of raster, vector and 3D formats, and run simple to advanced 
 spatial analysis and modeling. GRASS GIS can connect to spatial databases 
@@ -143,7 +143,7 @@ There are currently more than <b>300 extensions</b> in the
 <a href="https://github.com/OSGeo/grass-addons/tree/master/grass7">official GRASS Addons repo</a> 
 and many others in the wild to perform the most varied type of tasks.
 <br>Have a look at the full list of 
-<a href="https://grass.osgeo.org/grass-stable/manuals/addons/" target="_blank">addons manual pages</a> 
+<a href="/grass-stable/manuals/addons/" target="_blank">addons manual pages</a>
 to get an idea. If you don't find what you need, maybe you can 
 <a href="/contribute/development/">develop</a> your own add-on then.
 Read <a href="/download/addons/">here</a> to learn how to install them.</p>
@@ -151,7 +151,7 @@ Read <a href="/download/addons/">here</a> to learn how to install them.</p>
 
 
 <div class="col-lg-6 text-center">
-<img class="bsh" src="https://grass.osgeo.org/grass-stable/manuals/addons/number_seasons_ndvi.png" width="75%" alt="Output of r.seasons' addon">
+<img class="bsh" src="/grass-stable/manuals/addons/number_seasons_ndvi.png" width="75%" alt="Output of r.seasons' addon">
 </div>
 
 </div>

--- a/themes/grass/layouts/partials/quicklinks.html
+++ b/themes/grass/layouts/partials/quicklinks.html
@@ -1,25 +1,25 @@
 <div class="card mb-1-5 ">
-<h4 class="mt-20 tind"><i class="ms ms-vector ms-fw"></i> Vector <a href="https://grass.osgeo.org/grass79/manuals/vector.html" target="_blank">(v.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-vector ms-fw"></i> Vector <a href="/grass79/manuals/vector.html" target="_blank">(v.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-raster ms-fw"></i> Raster <a href="https://grass.osgeo.org/grass79/manuals/raster.html" target="_blank"> (r.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-raster ms-fw"></i> Raster <a href="/grass79/manuals/raster.html" target="_blank"> (r.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-img-o ms-fw"></i> Imagery <a href="https://grass.osgeo.org/grass79/manuals/imagery.html" target="_blank">(i.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-img-o ms-fw"></i> Imagery <a href="/grass79/manuals/imagery.html" target="_blank">(i.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-data-cube-o ms-fw"></i> Raster 3d <a href="https://grass.osgeo.org/grass79/manuals/raster3d.html" target="_blank">(r3.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-data-cube-o ms-fw"></i> Raster 3d <a href="/grass79/manuals/raster3d.html" target="_blank">(r3.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-database-o ms-fw"></i> Database <a href="https://grass.osgeo.org/grass79/manuals/database.html" target="_blank">(db.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-database-o ms-fw"></i> Database <a href="/grass79/manuals/database.html" target="_blank">(db.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="fa fa-clock-o fa-fw"></i> Temporal <a href="https://grass.osgeo.org/grass79/manuals/temporal.html" target="_blank">(t.*)</a></h4>
+<h4 class="mt-20 tind"><i class="fa fa-clock-o fa-fw"></i> Temporal <a href="/grass79/manuals/temporal.html" target="_blank">(t.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-map-rolled-o ms-fw"></i> Display <a href="https://grass.osgeo.org/grass79/manuals/display.html" target="_blank">(d.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-map-rolled-o ms-fw"></i> Display <a href="/grass79/manuals/display.html" target="_blank">(d.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-process ms-fw"></i> General <a href="https://grass.osgeo.org/grass79/manuals/general.html" target="_blank">(g.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-process ms-fw"></i> General <a href="/grass79/manuals/general.html" target="_blank">(g.*)</a></h4>
 </div>
 </div>


### PR DESCRIPTION
There should be no more need to have the URLs absolute.

Yet broken links after merging this PR might need a server-side intervention (e.g. missing redirects).