### PR TITLE
add page with mirrors sites and link on home page

### DIFF
--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -6,17 +6,11 @@ layout: "general"
 
 ### Official master site via HTTP/FTP
 
-
 * [Official master site: grass.osgeo.org](https://grass.osgeo.org/)
-
-* We recommend cascaded mirroring: 
-
-  * Tier-1 mirrors: These mirrors read daily from the master site and might also act as rsync servers. 
-  * Tier-2 mirrors: These mirrors read from the tier-1 mirrors (these sites may be 1-2 day(s) behind the master site)
 
 ### African Web site mirrors
 
-[South Africa](http://grass.mirror.ac.za) (Tier 1,TENET)
+* [South Africa](https://grass.mirror.ac.za/html/) (Tier 1,TENET)
 
 ### Asian-Indian Web site mirrors
 * [India](http://wgbis.ces.iisc.ernet.in/grass/) (Tier 2, Indian Institute of Science, Bangalore)

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -7,7 +7,7 @@ layout: "general"
 ### Official master site via HTTP/FTP
 
 
-* [Official master site: grass.osgeo.org](http://grass.osgeo.org/)
+* [Official master site: grass.osgeo.org](https://grass.osgeo.org/)
 
 * We recommend cascaded mirroring: 
 

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -1,0 +1,33 @@
+---
+title: "GRASS Website mirrors"
+date: 2020-07-28T16:13:30+02:00
+layout: "general"
+---
+
+### Official master site via HTTP/FTP
+
+
+* [Official master site: grass.osgeo.org](http://grass.osgeo.org/)
+
+* We recommend cascaded mirroring: 
+
+  * Tier-1 mirrors: These mirrors read daily from the master site and might also act as rsync servers. 
+  * Tier-2 mirrors: These mirrors read from the tier-1 mirrors (these sites may be 1-2 day(s) behind the master site)
+
+### African Web site mirrors
+
+[South Africa](http://grass.mirror.ac.za) (Tier 1,TENET)
+
+### Asian-Indian Web site mirrors
+* [India](http://wgbis.ces.iisc.ernet.in/grass/) (Tier 2, Indian Institute of Science, Bangalore)
+* [Japan](http://wgrass.media.osaka-cu.ac.jp/grassh/) (Tier 2, Osaka City University)
+* [South Korea](http://pinus.gntech.ac.kr/grass/) (Tier 2, Gyung-Nam National University of Science &amp; Technology)
+
+### European Web site mirrors
+
+* [Italy](http://grass.mirror.download.it) (Tier1)
+* [Czech Republic](http://grass.fsv.cvut.cz) (Tier2, Czech Technical University in Prague, Department of Geomatics)
+
+### US Web site mirrors
+
+* [USA](http://www.namesdir.com/mirrors/grass/) (Tier 2, St Louis)

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -1,5 +1,5 @@
 ---
-title: "GRASS Website mirrors"
+title: "GRASS GIS Website mirrors"
 date: 2020-07-28T16:13:30+02:00
 layout: "general"
 ---

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -5,6 +5,11 @@
        {{ with .Site.Params.copyright }} <p><small>{{ . }}</small></p> {{ end }}
       </div>
       <div class="col-md-4 text-md-left text-center">
+	{{if .IsHome}}
+	<p><small><a href="about/mirrors">Mirror sites</a></small></p>
+  {{end}}
+      </div>
+      <div class="col-md-4 text-md-left text-center">
 	{{if not .IsHome}}
 	<p><small><a href="https://github.com/OSGeo/grass-website/tree/master/content/{{ .Section }}/{{ with .File }}{{ .BaseFileName }}{{ end }}.md" class="fa fa-github"> <span class="edt">Edit this page on GitHub</span></a></small></p>
   {{end}}


### PR DESCRIPTION
First attempt at adding a list of mirror sites.
Current list certainly not up to date, so needs to be corrected before release.

I added the link only on the home page. Not sure if it should go somewhere else.

The actual page is in content/about/mirrors as we have no content directly in content/ and so I didn't want to put it there. About seemed the best for now.