### PR TITLE
fix description in head, suggestion by @mlennert 

### DIFF
--- a/themes/grass/layouts/partials/head.html
+++ b/themes/grass/layouts/partials/head.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html lang="{{ with .Site.LanguageCode }}{{.}}{{else }}en-US{{ end }}">
 <head>
-  <meta charset="utf-8">
+  {{ if .Params.description }}
+  <meta charset="utf-8" name="description" content="{{ .Params.description }}">
+  {{ else if .Site.Params.description }}
+  <meta charset="utf-8" name="description" content="{{ .Site.Params.description }}">
+  {{ end }}
   <title>{{ .Title }}</title>
   {{ hugo.Generator }}
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Following @mlennert's suggestion in https://github.com/OSGeo/grass-website/issues/205#issuecomment-665350781, I modified `head.html` and when inspecting the source code of home in the local build, the description is there. This should then fix #205.

![image](https://user-images.githubusercontent.com/20075188/88741602-64f34c80-d140-11ea-84a6-12a020da4317.png)
