### PR TITLE
move link to source code to the top of download landing page

### DIFF
--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -32,7 +32,21 @@
             </div>
           </div>
         </div>
+
+
         <div class="container">
+
+            <div class="section bg-white mb-4">
+                <div class="row nm">
+                  <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
+                  <div class="col-8">
+		    <h3 class="mt-20">GRASS GIS source code</h3>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>
+		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
+                  </div>
+                </div>
+              </div>
+
           <div class="row">
             <div class="col-lg-12">
 	      {{ range .Data.Pages }}
@@ -67,16 +81,6 @@
 		    <h3 class="mt-2 mb-2">GRASS GIS sample data</h3>
 		     <p>Download ready-to-use GRASS GIS sample datasets</p>
 		    <a class="btn btn-primary" href="{{.Site.BaseURL}}/download/data">Download</a>
-                  </div>
-                </div>
-		</div>
-	 <div class="section bg-white">
-                <div class="row nm">
-                  <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
-                  <div class="col-8">
-		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>
-		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Following suggestion in https://github.com/OSGeo/grass-website/issues/190#issuecomment-664411158, this PR moves the link to download the source code to the top of `Download` page to make it more visible while keeping the other download options visible too

![image](https://user-images.githubusercontent.com/20075188/88747067-50b64c00-d14e-11ea-98b1-0ce5e954710e.png)
