### PR TITLE
add link to releases in Download source code row

### DIFF
--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -42,7 +42,11 @@
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
 		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>
-		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
+		    <p><ul>
+                <li>Latest: <a href="https://github.com/OSGeo/grass">https://github.com/OSGeo/grass</a></li>
+                <li>Releases: <a href="https://github.com/OSGeo/grass/releases">https://github.com/OSGeo/grass/releases</a></li>
+               </ul>
+            </p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This is a draft proposal that tries to address an issue raised in this [thread](http://osgeo-org.1560.x6.nabble.com/Download-release-sources-td5443759.html) in the mailing list and discussed in #190. When adding a link to releases source code, I had to remove the nice style of the previous link to grass github repo, because it didn't look right when adding the link to releases too. 

![image](https://user-images.githubusercontent.com/20075188/90428440-48558f00-e0c4-11ea-902c-d5cb0f9ef25b.png)

There's an issue with vertically centering  the logo that I do not know how to fix either. 