### PR TITLE
add link to releases in download source code section

### DIFF
--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -41,7 +41,7 @@
                   <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a></p>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/releases">releases</a></p>
 		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>


### PR DESCRIPTION
This PR replaces #220 and implements the suggestion of @lucadelu to add a link to releases in the source code section of download page. Indentation not touched this time. 

![image](https://user-images.githubusercontent.com/20075188/90901340-147faf80-e3cb-11ea-8af0-dd94f81a55cb.png)
