### PR TITLE
fix tex tag for grass citation

### DIFF
--- a/content/about/license.md
+++ b/content/about/license.md
@@ -49,8 +49,7 @@ https://grass.osgeo.org/programming7/
 <p> Use the following BibTeX entry for citing the <b>GRASS GIS</b> software in 
 scientific work written in LaTeX.</p>
 
-<pre>
-<code class="hljs tex">
+```tex
 @Manual{GRASS_GIS_software,
     title = {Geographic Resources Analysis Support System (GRASS GIS) Software},
     author = {{GRASS Development Team}},
@@ -59,7 +58,6 @@ scientific work written in LaTeX.</p>
     year = {2020},
     url = {https://grass.osgeo.org}
 }
-</code>
-</pre>
+```
 
 For more options see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository).

--- a/content/about/license.md
+++ b/content/about/license.md
@@ -49,7 +49,7 @@ https://grass.osgeo.org/programming7/
 <p> Use the following BibTeX entry for citing the <b>GRASS GIS</b> software in 
 scientific work written in LaTeX.</p>
 
-```tex
+<pre style="background-color:#CCCCCC">
 @Manual{GRASS_GIS_software,
     title = {Geographic Resources Analysis Support System (GRASS GIS) Software},
     author = {{GRASS Development Team}},
@@ -58,6 +58,6 @@ scientific work written in LaTeX.</p>
     year = {2020},
     url = {https://grass.osgeo.org}
 }
-```
+</pre>
 
 For more options see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository).


### PR DESCRIPTION
The `@Manual` tag for GRASS citation was not visible within the `<pre>` and `<code>` HTML tags. This PR changes that to md code tag and now it is readable:

![image](https://user-images.githubusercontent.com/20075188/91193147-11503080-e6f7-11ea-80bb-2c0e80f1a6c7.png)
