### PR TITLE
footer: fix copyright symbol and add license

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ greyColorDark = "#A0A0A0"
   title = "GRASS GIS - Bringing advanced geospatial technologies to the world"
   dateFormat = "1 January 2019"
   logo = "GRASS GIS"
-  copyright = "Copyright &copy; 1998-2020, GRASS Development Team."
+  copyright = "1998-{year}, GRASS Development Team"
   license = "GNU GPL"
 
     # navigation

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -2,7 +2,7 @@
 <div class="container">
      <div class="row">
       <div class="col-md-4 text-md-left text-center">
-       {{ with .Site.Params.copyright }} <p><small>{{ . }}</small></p> {{ end }}
+       {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a>)</small></p> {{ end }}
       </div>
       <div class="col-md-4 text-md-left text-center">
         {{if .IsHome}}


### PR DESCRIPTION
Current footer contained:

"Copyright Â© 1998-2020"

With this PR it looks better:

![image](https://user-images.githubusercontent.com/1295172/93129146-d4ad9e80-f6d0-11ea-83ff-ae58a79be499.png)

as a bonus, it auto-increments the current year.

(Year code borrowed from https://github.com/wowchemy/wowchemy-hugo-modules/commit/5358dd00ad90fefcb50036c911382c46f38094b0 - MIT License)