### PR TITLE
Change grass79 to grass80

### DIFF
--- a/content/download/docker.en.md
+++ b/content/download/docker.en.md
@@ -56,14 +56,14 @@ For a version matrix (GRASS GIS, PROJ, GDAL, PDAL), see [here](https://github.co
 <i class="fa fa-info-circle"></i> The following Docker images are generated from the <b>GRASS GIS master branch</b>
 </div>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Ubuntu 18.04 based](https://hub.docker.com/r/neteler/grassgis7/) (<small>git master, grass80, 520 MB, with Python 3</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Ubuntu 18.04 based](https://hub.docker.com/r/neteler/grassgis7/) (<small>git main, grass80, 520 MB, with Python 3</small>)
     <pre><code class=dockerfile">docker pull neteler/grassgis7</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Alpine based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 320 MB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Alpine based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git main, grass80, 320 MB, with Python 3 and PDAL</small>)
     <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-alpine</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Debian 10 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 1.2 GB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Debian 10 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git main, grass80, 1.2 GB, with Python 3 and PDAL</small>)
    <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-debian</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 1.3 GB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git main, grass80, 1.3 GB, with Python 3 and PDAL</small>)
    <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-ubuntu</code></pre>

--- a/content/download/docker.en.md
+++ b/content/download/docker.en.md
@@ -9,7 +9,7 @@ layout: "os"
   
 #### Quick links
 
-[ [**GRASS GIS 7.8.x (current)**](#GRASS-GIS-current) | [**GRASS 7.6.x (old)**](#GRASS-GIS-old) | [**GRASS 7.9.x (unstable)**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.x (current)**](#GRASS-GIS-current) | [**GRASS 7.6.x (legacy)**](#GRASS-GIS-old) | [**GRASS 8.0.x (preview)**](#GRASS-GIS-devel) ]
 
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-arrow-right"></i> GRASS GIS <b>Docker images</b> provided and maintained by <a href="https://www.mundialis.de/en/" target="_blank">mundialis</a>.
@@ -43,27 +43,27 @@ For a version matrix (GRASS GIS, PROJ, GDAL, PDAL), see [here](https://github.co
 <i class="fa fa-info-circle"></i> The following Docker images are generated from the <b>GRASS GIS releasebranch_7_6</b> (<a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76">GRASS GIS 7.6.1 new features</a>)
 </div>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 7.6 stable, Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-gis-stable) (<small style="display:inline-block;margin-bottom:1em;">old stable, grass76, 730 MB, with Python 2</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 7.6 stable, Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-gis-stable) (<small style="display:inline-block;margin-bottom:1em;">release branch, grass76, 730 MB, with Python 2</small>)
    <pre><code class=dockerfile">docker pull mundialis/grass-gis-stable</code></pre>
 
 
 <hr>
 
 
-### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (preview)
+### <a name="GRASS-GIS-devel"></a> GRASS GIS 8.0 (preview)
 
 <div class="alert rounded-0 alert-info">
 <i class="fa fa-info-circle"></i> The following Docker images are generated from the <b>GRASS GIS master branch</b>
 </div>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 7.9 development, Ubuntu 18.04 based](https://hub.docker.com/r/neteler/grassgis7/) (<small>git master, grass79, 520 MB, with Python 3</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Ubuntu 18.04 based](https://hub.docker.com/r/neteler/grassgis7/) (<small>git master, grass80, 520 MB, with Python 3</small>)
     <pre><code class=dockerfile">docker pull neteler/grassgis7</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 7.9 development, Alpine based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass79, 320 MB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0 development, Alpine based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 320 MB, with Python 3 and PDAL</small>)
     <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-alpine</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 7.9.x development Debian 10 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass79, 1.2 GB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Debian 10 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 1.2 GB, with Python 3 and PDAL</small>)
    <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-debian</code></pre>
 
-*  [<i class="fa fa-download"></i> GRASS GIS 7.9.x development Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass79, 1.3 GB, with Python 3 and PDAL</small>)
+*  [<i class="fa fa-download"></i> GRASS GIS 8.0.x development Ubuntu 18.04 based](https://hub.docker.com/r/mundialis/grass-py3-pdal) (<small>git master, grass80, 1.3 GB, with Python 3 and PDAL</small>)
    <pre><code class="dockerfile">docker pull mundialis/grass-py3-pdal:latest-ubuntu</code></pre>

--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -8,7 +8,7 @@ layout: "os"
 
 #### Quick links
 
-[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 7.9 (devel)**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (legacy)**](#GRASS-GIS-old) | [**GRASS 8.0 (preview)**](#GRASS-GIS-devel) ]
 
 <hr>
 
@@ -50,13 +50,13 @@ list of GRASS GIS packages.
 
 <hr>
 
-### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (preview)
+### <a name="GRASS-GIS-devel"></a> GRASS GIS 8.0 (preview)
 
 <div class="alert rounded-0 alert-info">
 <i class="fa fa-info-circle"></i> Active <u>development</u>, <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
-*  [Generic 64bit](/grass79/binary/linux/snapshot/) (weekly binary snapshot)
+*  [Generic 64bit](/grass80/binary/linux/snapshot/) (weekly binary snapshot)
 
 <!-- *  [Ubuntu ](https://launchpad.net/~grass/+archive/ubuntu/grass-devel)  (ubuntugis-unstable) -->
 

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -8,7 +8,7 @@ layout: "os"
 
 #### Quick links
 
-[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 7.9 devel**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 8.0 (preview)**](#GRASS-GIS-devel) ]
 
 
 <div class="alert rounded-0 alert-default">
@@ -44,7 +44,7 @@ layout: "os"
 
 <hr>
 
-### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (preview)
+### <a name="GRASS-GIS-devel"></a> GRASS GIS 8.0 (preview)
 
 <div class="alert rounded-0 alert-info">
 <i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS GIS</b> version.

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -8,7 +8,7 @@ layout: "os"
 
 #### Quick links
 
-[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (old)**](#GRASS-GIS-old) | [**GRASS 8.0 (preview)**](#GRASS-GIS-devel) ]
+[ [**GRASS GIS 7.8.5 (current)**](#GRASS-GIS-current) | [**GRASS 7.6.1 (legacy)**](#GRASS-GIS-old) | [**GRASS 8.0 (preview)**](#GRASS-GIS-devel) ]
 
 
 <div class="alert rounded-0 alert-default">

--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -43,15 +43,15 @@ Standalone installer: install GRASS GIS with the required support packages.
 
 <hr>
 
-#### <a name="GRASS-GIS-devel"></a> GRASS GIS 7.9 (preview)
+#### <a name="GRASS-GIS-devel"></a> GRASS GIS 8.0 (preview)
 
 <div class="alert rounded-0 alert-info">
 <i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
 
-*  [<i class="fa fa-download"></i> Download 64bit](https://wingrass.fsv.cvut.cz/grass79/x86_64)
-*  [<i class="fa fa-download"></i> Download 32bit](https://wingrass.fsv.cvut.cz/grass79/x86)
+*  [<i class="fa fa-download"></i> Download 64bit](https://wingrass.fsv.cvut.cz/grass80/x86_64)
+*  [<i class="fa fa-download"></i> Download 32bit](https://wingrass.fsv.cvut.cz/grass80/x86)
 
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-arrow-right"></i> GRASS GIS <b> dev version for Windows </b> hosted by <a href="http://geomatics.fsv.cvut.cz/research/geoforall" target="_blank">GeoForAll Lab at the CTU in Prague</a>.

--- a/content/learn/manuals.md
+++ b/content/learn/manuals.md
@@ -8,8 +8,8 @@ layout: "manuals"
 
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl"><a href="/grass79/manuals/index.html " target="_blank"> GRASS GIS 7.9 (devel) </a></span>
-  <a href="/grass79/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="/grass79/manuals/grass-7.9_html_manual.zip" class="inl btn btn-secondary">Download ZIP</a>
+  <span class="mwl"><a href="/grass80/manuals/index.html " target="_blank"> GRASS GIS 8.0 (preview) </a></span>
+  <a href="/grass80/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="/grass80/manuals/grass-8.0_html_manual.zip" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
   <span class="mwl"><a href="/grass78/manuals/index.html " target="_blank"> GRASS GIS 7.8 (current) </a></span>
@@ -58,31 +58,31 @@ layout: "manuals"
 
 <ul id="links" class="list-unstyled version">
  <li>
-  <span class="mwl-l"><a href="/programming7/ " target="_blank">GRASS GIS 7 Programmer's Manual</a></span>
+  <span class="mwl-l"><a href="/programming8/ " target="_blank">GRASS GIS Programmer's Manual</a></span>
   <a href="/programming7/" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/master/doc/vector/v.example " target="_blank"> GRASS GIS 7 Example Vector Module in C</a></span>
-  <a href="https://github.com/OSGeo/grass/tree/master/doc/vector/v.example" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/main/doc/vector/v.example " target="_blank"> GRASS GIS Example Vector Module in C</a></span>
+  <a href="https://github.com/OSGeo/grass/tree/main/doc/vector/v.example" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/master/doc/raster/r.example " target="_blank"> GRASS GIS 7 Example Raster Module in C</a></span>
-  <a href="https://github.com/OSGeo/grass/tree/master/doc/raster/r.example" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/main/doc/raster/r.example " target="_blank"> GRASS GIS Example Raster Module in C</a></span>
+  <a href="https://github.com/OSGeo/grass/tree/main/doc/raster/r.example" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="/grass79/manuals/libpython/index.html " target="_blank"> GRASS GIS 7 Python Library Manual</a></span>
-  <a href="/grass79/manuals/libpython/index.html" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="/grass80/manuals/libpython/index.html " target="_blank"> GRASS GIS Python Library Manual</a></span>
+  <a href="/grass80/manuals/libpython/index.html" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://gitlab.com/vpetras/r.example.plus " target="_blank"> GRASS GIS 7 Example Python Module</a></span>
+  <span class="mwl-l"><a href="https://gitlab.com/vpetras/r.example.plus " target="_blank"> GRASS GIS Example Python Module</a></span>
   <a href="https://gitlab.com/vpetras/r.example.plus" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/master/doc/gui/wxpython/example " target="_blank"> GRASS GIS 7 Example GUI Module</a></span>
-  <a href="https://github.com/OSGeo/grass/tree/master/doc/gui/wxpython/example" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="https://github.com/OSGeo/grass/tree/main/doc/gui/wxpython/example " target="_blank"> GRASS GIS Example GUI Module</a></span>
+  <a href="https://github.com/OSGeo/grass/tree/main/doc/gui/wxpython/example" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
  <li>
-  <span class="mwl-l"><a href="/grass79/manuals/parser_standard_options.html " target="_blank"> GRASS GIS 7 Parser Standard Options</a></span>
-  <a href="/grass79/manuals/parser_standard_options.html" class="inl btn btn-primary" target="_blank">View HTML</a>
+  <span class="mwl-l"><a href="/grass80/manuals/parser_standard_options.html " target="_blank"> GRASS GIS Parser Standard Options</a></span>
+  <a href="/grass80/manuals/parser_standard_options.html" class="inl btn btn-primary" target="_blank">View HTML</a>
   </li>
 </ul>

--- a/content/learn/manuals.md
+++ b/content/learn/manuals.md
@@ -16,7 +16,7 @@ layout: "manuals"
   <a href="/grass78/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="/grass78/manuals/grass-7.8_html_manual.zip" class="inl btn btn-secondary">Download ZIP</a>
   </li>
    <li>
-  <span class="mwl"><a href="/grass76/manuals/index.html " target="_blank"> GRASS GIS 7.6 (old) </a></span>
+  <span class="mwl"><a href="/grass76/manuals/index.html " target="_blank"> GRASS GIS 7.6 (legacy) </a></span>
   <a href="/grass76/manuals/index.html" class="inl btn btn-primary" target="_blank">View HTML</a> <a href="/grass76/manuals/grass-7.6_html_manual.zip" class="inl btn btn-secondary">Download ZIP</a>
   </li>
 <!--

--- a/themes/grass/layouts/partials/quicklinks.html
+++ b/themes/grass/layouts/partials/quicklinks.html
@@ -1,25 +1,25 @@
 <div class="card mb-1-5 ">
-<h4 class="mt-20 tind"><i class="ms ms-vector ms-fw"></i> Vector <a href="/grass79/manuals/vector.html" target="_blank">(v.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-vector ms-fw"></i> Vector <a href="/grass80/manuals/vector.html" target="_blank">(v.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-raster ms-fw"></i> Raster <a href="/grass79/manuals/raster.html" target="_blank"> (r.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-raster ms-fw"></i> Raster <a href="/grass80/manuals/raster.html" target="_blank"> (r.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-img-o ms-fw"></i> Imagery <a href="/grass79/manuals/imagery.html" target="_blank">(i.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-img-o ms-fw"></i> Imagery <a href="/grass80/manuals/imagery.html" target="_blank">(i.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-data-cube-o ms-fw"></i> Raster 3d <a href="/grass79/manuals/raster3d.html" target="_blank">(r3.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-data-cube-o ms-fw"></i> Raster 3d <a href="/grass80/manuals/raster3d.html" target="_blank">(r3.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-database-o ms-fw"></i> Database <a href="/grass79/manuals/database.html" target="_blank">(db.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-database-o ms-fw"></i> Database <a href="/grass80/manuals/database.html" target="_blank">(db.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="fa fa-clock-o fa-fw"></i> Temporal <a href="/grass79/manuals/temporal.html" target="_blank">(t.*)</a></h4>
+<h4 class="mt-20 tind"><i class="fa fa-clock-o fa-fw"></i> Temporal <a href="/grass80/manuals/temporal.html" target="_blank">(t.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-map-rolled-o ms-fw"></i> Display <a href="/grass79/manuals/display.html" target="_blank">(d.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-map-rolled-o ms-fw"></i> Display <a href="/grass80/manuals/display.html" target="_blank">(d.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="ms ms-process ms-fw"></i> General <a href="/grass79/manuals/general.html" target="_blank">(g.*)</a></h4>
+<h4 class="mt-20 tind"><i class="ms ms-process ms-fw"></i> General <a href="/grass80/manuals/general.html" target="_blank">(g.*)</a></h4>
 </div>
 </div>


### PR DESCRIPTION
* change all appearances of `grass79` to `grass80` (with one exception: https://grass.osgeo.org/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst_grass79.zip)
* remove major version from developers manuals titles (developers manuals point always to the most recent version)
* use consistently `preview/legacy` term instead of `devel/old`
