### PR TITLE
tutorials.md: add intro tutorial on using commands

### DIFF
--- a/content/learn/tutorials.md
+++ b/content/learn/tutorials.md
@@ -51,7 +51,7 @@ layout: "overview"
 * [GRASS GIS 7 short course at GEOSTAT 2015: Course material](https://data.neteler.org/geostat2015/)
 * [Various GRASS GIS tutorials and user notes](https://ecodiv.earth/tutorials/)
 * [An introduction to GRASS GIS](https://baharmon.github.io/intro-to-grass)
-* [Using GRASS commands in a shell, in R and in RStudio](https://florisvdh.github.io/presentations/20210617_grass)
+* [Using GRASS commands in shell, R and RStudio](https://florisvdh.github.io/presentations/20210617_grass)
 
 ### Czech
 <img src="https://grasswiki.osgeo.org/w/images/ICC_workshop_3Dview_ortho.png" width="40%" style="float:right">

--- a/content/learn/tutorials.md
+++ b/content/learn/tutorials.md
@@ -51,6 +51,7 @@ layout: "overview"
 * [GRASS GIS 7 short course at GEOSTAT 2015: Course material](https://data.neteler.org/geostat2015/)
 * [Various GRASS GIS tutorials and user notes](https://ecodiv.earth/tutorials/)
 * [An introduction to GRASS GIS](https://baharmon.github.io/intro-to-grass)
+* [Using GRASS commands in a shell, in R and in RStudio](https://florisvdh.github.io/presentations/20210617_grass)
 
 ### Czech
 <img src="https://grasswiki.osgeo.org/w/images/ICC_workshop_3Dview_ortho.png" width="40%" style="float:right">


### PR DESCRIPTION
Proposing the addition of a basic, introductory presentation about GRASS 7.8 CLI setup, and the usage of GRASS commands in the shell, R and RStudio (given at my organization, a few months ago). Comments and improvements are also welcome at https://github.com/florisvdh/presentations/tree/master/src/20210617_grass. In the [third last](https://florisvdh.github.io/presentations/20210617_grass/#72) slide a simple demo (R markdown) is linked, using vector data & rasterization.

Thanks to @veroandreo for sharing the link to this `tutorials.md` file.