### PR TITLE
Download section: change link to tags instead of releases

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,41 +52,47 @@ greyColorDark = "#A0A0A0"
       name = "Download"
       url = "/download"
 
+    [[Languages.en.menu.main]]
+          parent = "Download"
+          name = "GRASS GIS source code"
+          URL = "https://github.com/OSGeo/grass/tags"
+          weight = 1
+
 	[[Languages.en.menu.main]]
           parent = "Download"
           name = "GRASS GIS for Linux"
           URL = "/download/linux"
-          weight = 1
-	  
+          weight = 2
+
  	[[Languages.en.menu.main]]
           parent = "Download"
           name = "GRASS GIS for Windows"
           URL = "/download/windows"
-          weight = 2
+          weight = 3
 
  	[[Languages.en.menu.main]]
           parent = "Download"
           name = "GRASS GIS for Mac"
           URL = "/download/mac"
-          weight = 3
+          weight = 4
 
  	[[Languages.en.menu.main]]
           parent = "Download"
           name = "Docker images"
           URL = "/download/docker"
-          weight = 4
+          weight = 5
 
     [[Languages.en.menu.main]]
           parent = "Download"
           name = "Addons"
           URL = "/download/addons"
-          weight = 5
+          weight = 6
 
  	[[Languages.en.menu.main]]
           parent = "Download"
           name = "Sample data"
           URL = "/download/data"
-          weight = 6
+          weight = 7
         
       [[Languages.en.menu.main]]
         weight = 3

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -41,7 +41,7 @@
                   <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/releases">releases</a></p>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/tags">release tags and tarballs</a></p>
 		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -41,7 +41,7 @@
                   <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/tags">release tags and tarballs</a></p>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all release tags' <a href="https://github.com/OSGeo/grass/tags">zip and tarball files</a>. Alternatively, find the latest tarballs and snapshots at <a href="https://grass.osgeo.org/grass80/source/">https://grass.osgeo.org/grass80/source/</a>. Or, clone the repo:</p>
 		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -41,7 +41,7 @@
                   <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all release tags' <a href="https://github.com/OSGeo/grass/tags">zip and tarball files</a>. Alternatively, find the latest tarballs and snapshots at <a href="https://grass.osgeo.org/grass80/source/">https://grass.osgeo.org/grass80/source/</a>. Or, clone the repo:</p>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/tags">source code archives</a> for releases (zip and tarball files). Alternatively, find the latest tarballs and snapshots at <a href="https://grass.osgeo.org/grass80/source/">https://grass.osgeo.org/grass80/source/</a>. Or, clone the repo:</p>
 		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
                   </div>
                 </div>


### PR DESCRIPTION
As suggested in the mailing list, I changed the link to point tags now for a straightforward link to tarballs:

![image](https://user-images.githubusercontent.com/20075188/153936776-f5000bc0-3e7c-40ef-85ca-98af9832cc90.png)

Other ideas about wording or layout preference are more than welcome :)
