### PR TITLE
Download section: replace command-like link by a button

### DIFF
--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -41,8 +41,8 @@
                   <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grasslogo.svg" class="grasslogo"></object></div>
                   <div class="col-8">
 		    <h3 class="mt-20">GRASS GIS source code</h3>
-		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/tags">source code archives</a> for releases (zip and tarball files). Alternatively, find the latest tarballs and snapshots at <a href="https://grass.osgeo.org/grass80/source/">https://grass.osgeo.org/grass80/source/</a>. Or, clone the repo:</p>
-		    <p class="command d-none d-lg-block"><a href="https://github.com/OSGeo/grass"> $ git clone https://github.com/OSGeo/grass </a></p>
+		    <p>The GRASS GIS source code is available on <a href="https://github.com/OSGeo/grass" target="_blank"><i class="fa fa-github"></i> Github</a>, see all <a href="https://github.com/OSGeo/grass/tags">source code archives</a> for releases (zip and tarball files). Alternatively, find the latest tarballs and snapshots at <a href="https://grass.osgeo.org/grass80/source/">https://grass.osgeo.org/grass80/source/</a>.</p>
+            <a class="btn btn-primary" href="https://github.com/OSGeo/grass" target="_blank">Clone me at <i class="fa fa-github"></i></a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
After adding the extra links in the Source code row in https://grass.osgeo.org/download/, the command-like link to the github repo does not appear when the site is displayed on mobile phones or when zooming in above 170% (in my laptop screen). Hence, I thought of replacing it by a button saying `Clone me` similar to the download buttons below. It looks like this: 

![image](https://user-images.githubusercontent.com/20075188/153963863-c2234e67-31c3-43a8-a6db-3d10f4695a8d.png)

and it does not disappear when zooming in a lot. On phones, I do not know. Anyway, an idea. What do you think?

PS: branch name does not really reflect the change as I originally thought it was a problem with row height (it might be indeed), but I didn't find a way to fix that. Hence, the button idea :wink: