### PR TITLE
TGIS schema for MODIS LST sample dataset updated (G8)

### DIFF
--- a/content/download/data.en.md
+++ b/content/download/data.en.md
@@ -68,8 +68,8 @@ The North Carolina dataset can be downloaded in two versions:
   </li>
   <li>
    <span class="mwl"><a href="/grass-stable/manuals/temporalintro.html" target="_blank"> Time series </a></span>
-   <a href="/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst.zip" class="inl btn btn-primary" target="_blank">Download ZIP (for < G7.8, 2 MB)</a>
-   <a href="/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst_grass79.zip" class="inl btn btn-primary" target="_blank">Download ZIP (for G79+, 2 MB)</a>
+   <a href="/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst.zip" class="inl btn btn-primary" target="_blank">Download ZIP (for G6, G7, 2 MB)</a>
+   <a href="/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst_grass8.zip" class="inl btn btn-primary" target="_blank">Download ZIP (for G8, 2 MB)</a>
    <p>MODIS Land Surface Temperature mapset (to unzip in NC location): MODIS LST raster time series (<a href="https://lpdaac.usgs.gov/products/mod11b3v006/">MOD11B3</a>, 6km, monthly)</p>
   </li>
 <!-- not sure?


### PR DESCRIPTION
Apply GRASS GIS 8 TGIS schema to MODIS LST sample dataset:

https://grass.osgeo.org/download/data/#NorthCarolinaDataset

- recreated MODIS LST time series for G8 from `nc_spm_mapset_modis2015_2016_lst.zip` usung `t.upgrade`, stored on server as `nc_spm_mapset_modis2015_2016_lst_grass8.zip`.
    - File uploaded: https://grass.osgeo.org/sampledata/north_carolina/nc_spm_mapset_modis2015_2016_lst_grass8.zip
- once PR is merged: `nc_spm_mapset_modis2015_2016_lst_grass79.zip` to be deleted on grass.osgeo.org server