### PR TITLE
Add MacPorts to Mac download page

### DIFF
--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -10,13 +10,11 @@ layout: "os"
 
 [ [**GRASS GIS 8.0 (current)**](#GRASS-GIS-current) | [**GRASS 7.8 (legacy)**](#GRASS-GIS-old) | [**GRASS 8.2 (preview)**](#GRASS-GIS-devel) ]
 
-
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-arrow-right"></i> Find <b>GRASS GIS binaries</b> on this website: <a href="http://grassmac.wikidot.com" target="_blank"> GRASS GIS for the Mac </a>
 </div>
 
 <hr>
-
 
 ### <a name="GRASS-GIS-current"></a> GRASS GIS 8.0.1 (current)
 
@@ -24,9 +22,8 @@ layout: "os"
 <i class="fa fa-info-circle"></i> <u>Current stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass8/NewFeatures80">GRASS GIS 8.0 new features</a> and <a href="https://github.com/OSGeo/grass/releases/tag/8.0.1">GRASS GIS 8.0.1 announcement</a> for more information.
 </div>
 
-<ul>
-<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
-</ul>
+*  [Download](http://grassmac.wikidot.com/downloads)
+*  [MacPorts](https://ports.macports.org/port/grass/)
 
 <hr>
 
@@ -36,11 +33,8 @@ layout: "os"
 <i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78">GRASS GIS 7.8 new features</a> and  <a href="https://github.com/OSGeo/grass/releases/tag/7.8.7">GRASS GIS 7.8.7 announcement</a> for more information.
 </div>
 
-<ul>
-<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
-</ul>
-
-
+*  [Download](http://grassmac.wikidot.com/downloads)
+*  [MacPorts](https://ports.macports.org/port/grass7/)
 
 <hr>
 
@@ -50,9 +44,6 @@ layout: "os"
 <i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
-<ul>
-<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
-</ul>
-
+*  [Download](http://grassmac.wikidot.com/downloads)
 
 <hr>

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -22,8 +22,12 @@ layout: "os"
 <i class="fa fa-info-circle"></i> <u>Current stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass8/NewFeatures80">GRASS GIS 8.0 new features</a> and <a href="https://github.com/OSGeo/grass/releases/tag/8.0.1">GRASS GIS 8.0.1 announcement</a> for more information.
 </div>
 
-*  [Download](http://grassmac.wikidot.com/downloads)
-*  [MacPorts](https://ports.macports.org/port/grass/)
+<ul>
+<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
+</ul>
+<ul>
+<li><a href="https://ports.macports.org/port/grass/"></i>MacPorts</a></li>
+</ul>
 
 <hr>
 
@@ -33,8 +37,12 @@ layout: "os"
 <i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78">GRASS GIS 7.8 new features</a> and  <a href="https://github.com/OSGeo/grass/releases/tag/7.8.7">GRASS GIS 7.8.7 announcement</a> for more information.
 </div>
 
-*  [Download](http://grassmac.wikidot.com/downloads)
-*  [MacPorts](https://ports.macports.org/port/grass7/)
+<ul>
+<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
+</ul>
+<ul>
+<li><a href="https://ports.macports.org/port/grass7/"></i>MacPorts</a></li>
+</ul>
 
 <hr>
 
@@ -44,6 +52,8 @@ layout: "os"
 <i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS GIS</b> version.
 </div>
 
-*  [Download](http://grassmac.wikidot.com/downloads)
+<ul>
+<li><a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a></li>
+</ul>
 
 <hr>


### PR DESCRIPTION
Now finally, GRASS 8 is available with the `grass` port.
This also adds the "old" port `grass7`.