### PR TITLE
content: fix broken links; master -> main; add student grants

### DIFF
--- a/content/about/credits.md
+++ b/content/about/credits.md
@@ -1,6 +1,6 @@
 ---
 title: "Credits"
-date: 2020-04-12T12:12:05+02:00
+date: 2022-04-25T10:12:05+02:00
 layout: "credits"
 ---
 
@@ -53,7 +53,7 @@ This website is licensed under the GNU General Public License v3.0<br>
 
 #### Copyright
 
-&#9400; Copyright, 1998-2020 GRASS Development Team
+&#9400; Copyright, 1998-2022 GRASS Development Team
 
 #### Acknowledgments
 

--- a/content/about/history/releases.md
+++ b/content/about/history/releases.md
@@ -1,6 +1,6 @@
 ---
 title: "History"
-date: 2020-04-10T12:12:15+02:00
+date: 2022-04-25T10:12:05+02:00
 layout: "timeline"
 ---
 
@@ -53,7 +53,7 @@ layout: "timeline"
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 09 Nov 2019</span> <b>GRASS GIS 7.8.1</b> &#160; <a href="https://trac.osgeo.org/grass/wiki/Release/7.8.1-News">Changelog</a> - <a href="/grass78/source/">Source Code</a></li>
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 06 Sep 2019 </span> <b>GRASS GIS 7.8.0</b> &#160; <a href="https://trac.osgeo.org/grass/wiki/Release/7.8.0-News">Changelog</a>  - <a href="/grass78/source/">Source Code</a> - <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78"><b>New Features 7.8</b></a></li>
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 04 Aug 2019</span> Creation of the GRASS GIS 7.8 release branch (<a href="https://github.com/OSGeo/grass/tree/releasebranch_7_8">d4879d4</a>)</li>
-<!-- find with git log releasebranch_7_8 (not master) -->
+<!-- find with git log releasebranch_7_8 (not main) -->
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 19 Mar 2019</span> <b>GRASS GIS 7.6.1</b> &#160; <a href="/grass76/source/ChangeLog_7.6.1.gz">ChangeLog</a> - <a href="/grass76/source/">Source Code</a></li>
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 17 Jan 2019</span> <b>GRASS GIS 7.6.0</b> &#160;  <a href="/grass76/source/ChangeLog_7.6.0.gz">ChangeLog</a> - <a href="/grass76/source/">Source Code</a> - <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76"><b>New Features 7.6</b></a></li>
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 04 Jan 2019</span> <b>GRASS GIS 7.4.4</b> &#160; <a href="/grass74/source/ChangeLog_7.4.4.gz">ChangeLog</a> - <a href="/grass74/source/">Source Code</a></li>

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -1,12 +1,12 @@
 ---
 title: "GRASS GIS Website mirrors"
-date: 2020-07-28T16:13:30+02:00
+date: 2022-04-25T10:12:05+02:00
 layout: "general"
 ---
 
-### Official master site via HTTP/FTP
+### Official main site via HTTP/FTP
 
-* [Official master site: grass.osgeo.org](https://grass.osgeo.org/) in the USA
+* [Official main site: grass.osgeo.org](https://grass.osgeo.org/) in the USA
 
 ### African Web site mirrors
 
@@ -14,11 +14,12 @@ layout: "general"
 * [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
 
 ### Asian-Indian Web site mirrors
+
 * [India](http://wgbis.ces.iisc.ernet.in/grass/) (Tier 2, Indian Institute of Science, Bangalore)
-* [Japan](http://wgrass.media.osaka-cu.ac.jp/grassh/) (Tier 2, Osaka City University)
-* [South Korea](http://pinus.gntech.ac.kr/grass/) (Tier 2, Gyung-Nam National University of Science &amp; Technology)
+<!-- * [Japan](http://wgrass.media.osaka-cu.ac.jp/grassh/) (Tier 2, Osaka City University) -->
+<!-- * [South Korea](http://pinus.gntech.ac.kr/grass/) (Tier 2, Gyung-Nam National University of Science &amp; Technology) -->
 
 ### European Web site mirrors
 
 * [Italy](http://grass.mirror.download.it) (Tier1)
-* [Czech Republic](http://grass.fsv.cvut.cz) (Tier2, Czech Technical University in Prague, Department of Geomatics)
+<!-- * [Czech Republic](http://grass.fsv.cvut.cz) (Tier2, Czech Technical University in Prague, Department of Geomatics) -->

--- a/content/contribute/_index.en.md
+++ b/content/contribute/_index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Contribute"
-date: 2020-07-28T11:02:05+05:00
+date: 2022-04-25T10:12:05+02:00
 icon: "fa fa-user"
 description: "Contribute to Open Source Geospatial through GRASS GIS development"
 type : "pages"
@@ -17,7 +17,7 @@ All new submissions in the tracker will be automatically forwarded to the GRASS 
 ###### Some recommendations
 <small>
 <ul>
- <li>Check if the bug you found is still present in the current stable release version or, better, in the "master" version before reporting. If you use an older version, please consider to [upgrade](/download) first.</li>
+ <li>Check if the bug you found is still present in the current stable release version or, better, in the "main" version before reporting. If you use an older version, please consider to [upgrade](/download) first.</li>
  <li>Make sure that the developers have all the information needed to reproduce the bug (e.g. explain how to reproduce the bug using the [North Carolina example dataset](/download/data))</li>
  <li>Report only a single bug or feature request with each issue</li>
  <li>Before reporting a bug, please check that it hasn't been reported already in the [GRASS GIS bugtracking system](https://github.com/OSGeo/grass/issues)</li>
@@ -77,7 +77,7 @@ A GRASS mirror site requires around 14 GB space, the space requirements may vary
 If you would like to support the GRASS community, do not hesitate to set up your mirror site.
 
 #### How to set up a mirror site:
-The master site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](http://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using "rsync" mirror software is that only changed files are transferred which minimizes the network traffic.
+The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](http://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using "rsync" mirror software is that only changed files are transferred which minimizes the network traffic.
 
 #### Mirror site setup in greater detail:
 
@@ -92,6 +92,14 @@ The master site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsy
 
 ### Other opportunities
 
+#### Student Grants
+
+**Student Grants is a stipend program for students by the GRASS GIS project.**
+
+The GRASS GIS project offers a limited number of student grants for projects related to GRASS GIS. These can include actual coding, bug fixing, or documentation and the creation of educational resources.
+
+For details, see [Student Grants](https://grasswiki.osgeo.org/wiki/Student_Grants).
+
 #### Google Summer of Code (GSoC)
 
 **GSoC is a stipend program for students by Google.**
@@ -102,7 +110,7 @@ will pay a monthly stipend for 3 months.
 
 #### Google Code-in (GCI)
 
-**GCI is an online contest introducing high school students to open source development**.
+**GCI is an online contest introducing high school students to open source development.**
 
 Students can participate with the [OSGeo organization](https://codein.withgoogle.com/organizations/osgeo/) 
 and solve tasks for different projects. Tasks might include documentation, design, coding, etc.

--- a/content/contribute/development.md
+++ b/content/contribute/development.md
@@ -1,6 +1,6 @@
 ---
 title: "Development"
-date: 2020-04-12T11:02:05+02:00
+date: 2022-04-25T10:02:05+02:00
 layout: "devel"
 ---
 
@@ -9,9 +9,9 @@ GRASS - **Geographic Resources Analysis Support System** has been under continuo
 <img src="/images/other/Grass_osgeo_codesprint_2018.jpg" width="40%" alt="" align="left" class="mr-3 pt-2">
 
 The strength and success of GRASS GIS relies on the **user community** to improve and extend the GRASS GIS capabilities.
-GRASS GIS is developed and supported by a [worldwide team of developers](https://github.com/OSGeo/grass/blob/master/contributors.csv).
+GRASS GIS is developed and supported by a [worldwide team of developers](https://github.com/OSGeo/grass/blob/main/contributors.csv).
 
 Many people have contributed to GRASS GIS throughout time. Without them, GRASS GIS would not exist in its current form.
 The authors of the individual programs or modules are listed at the end of the respective manual pages.
 
-Read [CONTRIBUTING](https://github.com/OSGeo/grass/blob/master/CONTRIBUTING.md) file to start to contribute in GRASS GIS development.
+Read [CONTRIBUTING](https://github.com/OSGeo/grass/blob/main/CONTRIBUTING.md) file to start to contribute in GRASS GIS development.

--- a/content/download/docker.en.md
+++ b/content/download/docker.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Docker"
-date: 2020-10-10T11:02:05+02:00
+date: 2022-04-25T10:12:05+02:00
 description: "Download GRASS GIS Docker images"
 weight: 4
 layout: "os"
@@ -15,7 +15,7 @@ layout: "os"
 <i class="fa fa-arrow-right"></i> GRASS GIS <b>Docker images</b> provided and maintained by <a href="https://www.mundialis.de/en/" target="_blank">mundialis</a>.
 </div>
 
-For a version matrix (GRASS GIS, PROJ, GDAL, PDAL), see [here](https://github.com/OSGeo/grass/blob/master/docker/README.md)
+For a version matrix (GRASS GIS, PROJ, GDAL, PDAL), see [here](https://github.com/OSGeo/grass/blob/main/docker/README.md)
 
 <hr>
 

--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "What is GRASS GIS?"
-date: 2020-07-28T11:02:05+06:00
+date: 2022-04-25T10:12:05+02:00
 layout: "overview"
 ---
 
@@ -140,7 +140,7 @@ GRASS GIS can be used through various interfaces:
 list of <b>extensions or addons</b>. These modules are contributed by users
 or developers but are not yet part of the standard distribution.
 There are currently more than <b>300 extensions</b> in the 
-<a href="https://github.com/OSGeo/grass-addons/tree/master/grass7">official GRASS Addons repo</a> 
+<a href="https://github.com/OSGeo/grass-addons/tree/grass8">official GRASS Addons repo</a>
 and many others in the wild to perform the most varied type of tasks.
 <br>Have a look at the full list of 
 <a href="/grass-stable/manuals/addons/" target="_blank">addons manual pages</a>


### PR DESCRIPTION
While also this repo should be updated from master -> main in a different PR,
this PR updates links to various GRASS GIS GitHub repos in this regard.

Link update to GRASS GIS addons repo.

Commented out (currently?) broken mirror sites.

Also added: "[Student Grants](https://grasswiki.osgeo.org/wiki/Student_Grants)".