### PR TITLE
Hugo update and updated css outline rules

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,7 +24,10 @@ greyColorDark = "#A0A0A0"
   priority = 0.5
 
 [markup]
-  defaultMarkdownHandler = "blackfriday"
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
   
 [Languages]
 

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -171,10 +171,7 @@ a.nws:hover {
   z-index: 1;
   transition: .2s ease;
 }
-.btn:focus {
-  outline: 0;
-  box-shadow: none !important;
-}
+
 .btn:active {
   box-shadow: none;
 }
@@ -182,16 +179,14 @@ a.nws:hover {
   background: var(--grass-color-alt);
   color: var(--white-color);
 }
-.btn-primary:hover {
+.btn-primary:hover, .btn-primary:focus {
   background: var(--grass-color);
   color: var(--white-color) !important;
 }
 .btn-primary:active {
   background: var(--grass-color);
 }
-.btn-primary:hover {
-  background: var(--grass-color);
-}
+
 .btn-primary:not(:disabled):not(.disabled).active, .btn-primary:not(:disabled):not(.disabled):active, .show>.btn-primary.dropdown-toggle {
   color: var(--white-color);
   background-color: var(--primary-color);
@@ -204,7 +199,7 @@ a.nws:hover {
 .btn-secondary:active {
   background: var(--grey-color-dark);
 }
-.btn-secondary:hover {
+.btn-secondary:hover, .btn-secondary:focus {
   background: var(--grey-color-dark);
   color: var(--white-color) !important;
 }
@@ -267,12 +262,6 @@ a:hover {
 a, button, select {
   cursor: pointer;
   transition: .2s ease;
-}
-a:focus, button:focus, select:focus {
-  outline: 0;
-}
-.slick-slide {
-  outline: 0;
 }
 .section {
   padding-top: 30px;
@@ -414,9 +403,6 @@ pre {
 }
 
 
-.outline-0 {
-  outline: 0 !important;
-}
 .d-unset {
   display: unset !important;
 }


### PR DESCRIPTION
- Updated defaultMarkdownHandler as 'blackfriday' was removed from Hugo in [v0.100.2](https://www.opensourceagenda.com/projects/hugo/versions)

- Updated css rules for outline. It is good practice to have the ouline, as it helps locate the current focused element when tab navigating
