### PR TITLE
fix img that was not displayed in learn/overview

### DIFF
--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -122,7 +122,7 @@ GRASS GIS can be used through various interfaces:
 <li><a href="https://grasswiki.osgeo.org/wiki/GRASS_GIS_Jupyter_notebooks" target="_blank">Jupyter Notebooks</a>.</li>
 <li><strong>Web interface</strong> through <a href="https://grasswiki.osgeo.org/wiki/WPS" target="_blank">WPS servers</a>.</li>
 <li><a href="https://docs.qgis.org/3.10/en/docs/user_manual/grass_integration/grass_integration.html" target="_blank">QGIS</a> provides two different ways to run GRASS GIS modules: Processing toolbox and the GRASS GIS plugin.</li>
-<li>R provides an <a href="https://grasswiki.osgeo.org/wiki/R_statistics" target="_blank">interface to GRASS GIS</a> through the package <strong><i>rgrass7</i></strong>.</li>
+<li>R provides an <a href="https://grasswiki.osgeo.org/wiki/R_statistics" target="_blank">interface to GRASS GIS</a> through the package <strong><i>rgrass</i></strong>.</li>
 <li>It is also possible to <a href="/learn/tryonline" target="_blank">try GRASS online</a>!</li>
 </ul>
 </div>

--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -151,7 +151,7 @@ Read <a href="/download/addons/">here</a> to learn how to install them.</p>
 
 
 <div class="col-lg-6 text-center">
-<img class="bsh" src="/grass-stable/manuals/addons/number_seasons_ndvi.png" width="75%" alt="Output of r.seasons' addon">
+<img class="bsh" src="https://grass.osgeo.org/grass-stable/manuals/addons/number_seasons_ndvi.png" width="75%" alt="Output of r.seasons' addon">
 </div>
 
 </div>


### PR DESCRIPTION
The last image was not displayed, seems the full website of the img is needed.