### PR TITLE
community: added section "Question-and-answer (Q&A) websites"

### DIFF
--- a/content/about/community.md
+++ b/content/about/community.md
@@ -1,6 +1,6 @@
 ---
 title: "Community"
-date: 2020-07-28T11:02:05+06:00
+date: 2022-08-08T11:02:05+06:00
 layout: "community"
 ---
 
@@ -44,7 +44,13 @@ Subscribe to start the conversation, and please follow the <a href="https://gras
 | *Git Commit*  | [grass-commits](https://lists.osgeo.org/mailman/listinfo/grass-commit) | GRASS GIS git commit mailing list |
 | *Website*  | [grass-web](https://lists.osgeo.org/mailman/listinfo/grass-web) | GRASS GIS website mailing list |
 | *Announcement*  |  [grass-announce](https://lists.osgeo.org/mailman/listinfo/grass-announce) | General GRASS GIS project announcements |
-| *GitHub Discussions*  | [discussion](https://github.com/OSGeo/grass/discussions) | GitHub Discussions for GRASS GIS |
+
+### Question-and-answer (Q&A) websites
+
+| <div style="width:70px">MEDIA</div> | LINK |  |
+|------|---------|-------------|
+| <i class="fa fa-github"></i> |  [GitHub discussion](https://github.com/OSGeo/grass/discussions) | GitHub Discussions for GRASS GIS |
+| <i class="fa fa-stack-exchange"></i> |  [https://gis.stackexchange.com](https://gis.stackexchange.com/questions/tagged/grass) | GRASS GIS on Stackexchange |
 
 ### Social media
 

--- a/content/about/community.md
+++ b/content/about/community.md
@@ -48,7 +48,7 @@ Subscribe to start the conversation, and please follow the <a href="https://gras
 ### Q&A websites
 
 <div class="alert rounded-0 alert-default">
-Discussions in Q&A style may be held on these sites; you need to first register to participate.
+Discussions in question and answer (Q&A) style may be held on these sites; you need to first register to participate.
 </div>
 
 | <div style="width:70px">MEDIA</div> | LINK |  |

--- a/content/about/community.md
+++ b/content/about/community.md
@@ -45,7 +45,7 @@ Subscribe to start the conversation, and please follow the <a href="https://gras
 | *Website*  | [grass-web](https://lists.osgeo.org/mailman/listinfo/grass-web) | GRASS GIS website mailing list |
 | *Announcement*  |  [grass-announce](https://lists.osgeo.org/mailman/listinfo/grass-announce) | General GRASS GIS project announcements |
 
-### Question-and-answer (Q&A) websites
+### Q&A websites
 
 <div class="alert rounded-0 alert-default">
 Discussions in Q&A style may be held on these sites; you need to first register to participate.

--- a/content/about/community.md
+++ b/content/about/community.md
@@ -47,6 +47,10 @@ Subscribe to start the conversation, and please follow the <a href="https://gras
 
 ### Question-and-answer (Q&A) websites
 
+<div class="alert rounded-0 alert-default">
+Discussions in Q&A style may be held on these sites; you need to first register to participate.
+</div>
+
 | <div style="width:70px">MEDIA</div> | LINK |  |
 |------|---------|-------------|
 | <i class="fa fa-github"></i> |  [GitHub discussion](https://github.com/OSGeo/grass/discussions) | GitHub Discussions for GRASS GIS |


### PR DESCRIPTION
- moved "GitHub Discussions for GRASS GIS" from "Mailing lists" section here for a better fit
- added "GRASS GIS on Stackexchange"

Preview:

![image](https://user-images.githubusercontent.com/1295172/183411506-d0bf0e12-e23c-46fe-8fdd-a18fa5fb851d.png)



Fixes #313