### PR TITLE
sitemap: bring SEO back through use of versions in URLs

### DIFF
--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -4,12 +4,12 @@
       <loc>https://grass.osgeo.org/sitemap_hugo.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass-stable/manuals/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass82/manuals/sitemap_manuals.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass-stable/manuals/addons/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass82/manuals/addons/sitemap_manuals.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass-devel/manuals/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass83/manuals/sitemap_manuals.xml</loc>
    </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Apparently the use of `grass-stable/` and `grass-devel/` penalizes the new GRASS GIS 8 versions over G78 in common search engines.
Reason may be that they are only redirects which cannot be easily ranked.

This PR brings back the GRASS GIS version in the manual URLs (followup to #230) and to be considered in #318.