### PR TITLE
Tutorials list: Clean-up and reorganization

### DIFF
--- a/content/learn/tutorials.md
+++ b/content/learn/tutorials.md
@@ -29,29 +29,35 @@ layout: "overview"
 
 <img src="https://grasswiki.osgeo.org/w/images/WxGUI_set_region.png" width="50%" style="float:right">
 
-* [Introduction to GRASS GIS](http://ncsu-geoforall-lab.github.io/grass-intro-workshop/)
-* [GRASS GIS Workshop in Jena with updates](https://training.gismentors.eu/grass-gis-workshop-jena/)
-* [Introduction to GRASS GIS with terrain analysis examples](https://grasswiki.osgeo.org/wiki/Introduction_to_GRASS_GIS_with_terrain_analysis_examples)
-* [Unleash the power of GRASS GIS](https://grasswiki.osgeo.org/wiki/Unleash_the_power_of_GRASS_GIS_at_US-IALE_2017)
-* [From GRASS GIS novice to power user](https://grasswiki.osgeo.org/wiki/From_GRASS_GIS_novice_to_power_user_(workshop_at_FOSS4G_Boston_2017))
-* [GRASS GIS IRSAE Winter Course 2018](https://training.gismentors.eu/grass-gis-irsae-winter-course-2018/)
-* [Using GRASS GIS through Python and tangible interfaces](https://grasswiki.osgeo.org/wiki/Using_GRASS_GIS_through_Python_and_tangible_interfaces_(workshop_at_FOSS4G_NA_2016))
-* [Analytical data visualizations](https://grasswiki.osgeo.org/wiki/Analytical_data_visualizations_at_ICC_2017)
-* [Processing LiDAR and UAV point clouds in GRASS GIS](https://grasswiki.osgeo.org/wiki/Processing_lidar_and_UAV_point_clouds_in_GRASS_GIS_(workshop_at_FOSS4G_Boston_2017))
+##### Basic tutorials
+
+* [Unleash the power of GRASS GIS with Jupyter](https://github.com/ncsu-geoforall-lab/grass-gis-workshop-foss4g-2022) (2022)
+* [Unleash the power of GRASS GIS](https://grasswiki.osgeo.org/wiki/Unleash_the_power_of_GRASS_GIS_at_US-IALE_2017) (2017)
+* [From GRASS GIS novice to power user](https://grasswiki.osgeo.org/wiki/From_GRASS_GIS_novice_to_power_user_(workshop_at_FOSS4G_Boston_2017)) (2017)
+* [Analytical data visualizations](https://grasswiki.osgeo.org/wiki/Analytical_data_visualizations_at_ICC_2017) (2017)
+* [Introduction to GRASS GIS](http://ncsu-geoforall-lab.github.io/grass-intro-workshop/) (2016)
+
+##### Advanced tutorials
+
+* [GRASS GIS for remote sensing data processing and analysis](https://github.com/veroandreo/foss4g2022_grass4rs) (2022)
+* [Various GRASS GIS tutorials for ecological applications](https://ecodiv.earth/tutorials/) (2022)
+* [Temporal data processing](https://grasswiki.osgeo.org/wiki/Temporal_data_processing) (2021)
+* [Analyzing space-time satellite data for disease ecology](https://github.com/veroandreo/grass_opengeohub2019/blob/master/pdf/tgrass_rstats_disease_ecology.pdf) (2021)
+* [Using GRASS commands in shell, R and RStudio](https://florisvdh.github.io/presentations/20210617_grass) (2021)
+* [Time series processing with GRASS GIS](https://github.com/veroandreo/grass_opengeohub2019/blob/master/pdf/tgrass_lst.pdf) (2019)
 <img src="https://grasswiki.osgeo.org/w/images/Wxgui_module_parameters_r_neighbors.png" width="40%" style="float:right">
-* [Geospatial Modeling and Analysis](http://ncsu-geoforall-lab.github.io/geospatial-modeling-course/grass/)
-* [Workshop on urban growth modeling with FUTURES](https://grasswiki.osgeo.org/wiki/Workshop_on_urban_growth_modeling_with_FUTURES)
-* [Spatio-temporal data handling and visualization in GRASS GIS](http://ncsu-geoforall-lab.github.io/grass-temporal-workshop/)
-* [Temporal data processing](https://grasswiki.osgeo.org/wiki/Temporal_data_processing)
-* [Time series processing with GRASS GIS](https://github.com/veroandreo/grass_opengeohub2019/blob/master/pdf/tgrass_lst.pdf)
-* [Analyzing space-time satellite data for disease ecology](https://github.com/veroandreo/grass_opengeohub2019/blob/master/pdf/tgrass_rstats_disease_ecology.pdf)
-* [actinia tutorial at OpenGeoHub Summer School 2019](https://neteler.gitlab.io/actinia-introduction/)
-* [GRASS GIS courses in OSGeo Resources](https://www.osgeo.org/resources/)
-* [GIS for Designers](https://baharmon.github.io/gis-for-designers)
-* [GRASS GIS 7 short course at GEOSTAT 2015: Course material](https://data.neteler.org/geostat2015/)
-* [Various GRASS GIS tutorials and user notes](https://ecodiv.earth/tutorials/)
-* [An introduction to GRASS GIS](https://baharmon.github.io/intro-to-grass)
-* [Using GRASS commands in shell, R and RStudio](https://florisvdh.github.io/presentations/20210617_grass)
+* [Processing LiDAR and UAV point clouds in GRASS GIS](https://grasswiki.osgeo.org/wiki/Processing_lidar_and_UAV_point_clouds_in_GRASS_GIS_(workshop_at_FOSS4G_Boston_2017)) (2017)
+* [Using GRASS GIS through Python and tangible interfaces](https://grasswiki.osgeo.org/wiki/Using_GRASS_GIS_through_Python_and_tangible_interfaces_(workshop_at_FOSS4G_NA_2016)) (2016)
+* [Workshop on urban growth modeling with FUTURES](https://grasswiki.osgeo.org/wiki/Workshop_on_urban_growth_modeling_with_FUTURES) (2016)
+* [Spatio-temporal data handling and visualization in GRASS GIS](http://ncsu-geoforall-lab.github.io/grass-temporal-workshop/) (2014)
+
+##### Full courses
+
+* [GRASS GIS 8](https://www.youtube.com/playlist?list=PLSCH2IXZ2pHrUXXuOK7EBKWmMD7i6CTA-) (Videos - 2022)
+* [GRASS GIS Course in Jena](https://training.gismentors.eu/grass-gis-workshop-jena/) (2022)
+* [Geospatial Modeling and Analysis](http://ncsu-geoforall-lab.github.io/geospatial-modeling-course/grass/) (2022)
+* [GIS for Designers](https://baharmon.github.io/gis-for-designers) (2021)
+* [GRASS GIS IRSAE Winter Course](https://training.gismentors.eu/grass-gis-irsae-winter-course-2018/) (2019)
 
 ### Czech
 <img src="https://grasswiki.osgeo.org/w/images/ICC_workshop_3Dview_ortho.png" width="40%" style="float:right">
@@ -83,6 +89,7 @@ layout: "overview"
 
 ### Spanish
 
+* [Clases sobre Teledeteccion, OBIA y series de tiempo en GRASS](https://gitlab.com/veroandreo/maie-procesamiento/-/tree/taller-grass-online) (2021)
 * [Visualizacion analitica de datos](https://grasswiki.osgeo.org/wiki/Analytical_data_visualizations_at_ICC_2017/es)
 * [Libera el poder de GRASS GIS](https://grasswiki.osgeo.org/wiki/Unleash_the_power_of_GRASS_GIS_at_US-IALE_2017/es)
 * [Procesamiento de datos LiDAR y de UAV](https://grasswiki.osgeo.org/wiki/Processing_lidar_and_UAV_point_clouds_in_GRASS_GIS_(workshop_at_FOSS4G_Boston_2017)/es)

--- a/content/learn/tutorials.md
+++ b/content/learn/tutorials.md
@@ -29,7 +29,7 @@ layout: "overview"
 
 <img src="https://grasswiki.osgeo.org/w/images/WxGUI_set_region.png" width="50%" style="float:right">
 
-##### Basic tutorials
+##### Introductory tutorials
 
 * [Unleash the power of GRASS GIS with Jupyter](https://github.com/ncsu-geoforall-lab/grass-gis-workshop-foss4g-2022) (2022)
 * [Unleash the power of GRASS GIS](https://grasswiki.osgeo.org/wiki/Unleash_the_power_of_GRASS_GIS_at_US-IALE_2017) (2017)


### PR DESCRIPTION
I have reorganized the tutorials' list by creating subsections and adding date of last update between parenthesis. The latest FOSS4G tutorials were also added along with a link to Isaac's videos on GRASS 8. This is how it looks:

![image](https://user-images.githubusercontent.com/20075188/187033278-c4cd6e0e-7100-429b-8083-edd30ad0229b.png)
