### PR TITLE
add chat icon to footer - partially address #329

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -223,7 +223,11 @@ greyColorDark = "#A0A0A0"
     [[Languages.en.socialIcon]]
       icon = " fa fa-github"
       link = "https://github.com/OSGeo/grass"
-      
+
+    [[Languages.en.socialIcon]]
+          icon = " fa fa-comments"
+          link = "https://gitter.im/grassgis/community"
+
     [[Languages.en.socialIcon]]
       icon = " fa fa-twitter"
       link = "https://twitter.com/grassgis"    


### PR DESCRIPTION
There's no icon for Gitter in the fontawesome 4.7 that we are supporting, so for now I used the comment icon:

![image](https://user-images.githubusercontent.com/20075188/187064603-f59b9ef1-0bb0-4648-8599-88db0e8cf8b9.png)

Updating the fontawesome icon set is wip...