### PR TITLE
donate link in donate dialog

### DIFF
--- a/themes/grass/layouts/shortcodes/donateDialog.html
+++ b/themes/grass/layouts/shortcodes/donateDialog.html
@@ -26,7 +26,7 @@
             While downloading your <em>free</em> and <em>open source</em> copy of <strong>GRASS GIS</strong>, if you or your 
             institution enjoy the software 
             please consider making a  
-            <a href="https://opencollective.com/osgeo/projects/grass#section-contribute">
+            <a href="https://opencollective.com/osgeo/projects/grass/donate">
               <strong>
                 donation to support the project</strong></a>.
              May the FOSS be with you!
@@ -41,7 +41,7 @@
             </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <a   class="btn btn-primary-active" href="https://opencollective.com/osgeo/projects/grass#section-contribute">Donate</a>
+          <a   class="btn btn-primary-active" href="https://opencollective.com/osgeo/projects/grass/donate">Donate</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## what / why
changed the link in donate dialog to point directly to donate page in opencollective.com instead of the project page  (1 click less to donate)