### PR TITLE
User statistics: add matomo javascript code snippet

### DIFF
--- a/content/about/privacy.md
+++ b/content/about/privacy.md
@@ -1,0 +1,24 @@
+---
+title: "Privacy policy"
+date: 2022-10-15T05:05:05+05:00
+layout: "general"
+---
+
+### Privacy policy
+
+#### Analytics
+
+**Matomo**
+
+This website uses the open source web analytics service [Matomo](https://matomo.org/). Matomo uses technologies that enable the recognition of the user across pages for the analysis of user behaviour (e.g. cookies or device fingerprinting). The information collected by Matomo about the use of this website is stored on our server. The IP address is anonymised before storage.
+With the help of Matomo, we are able to collect and analyse data about the use of our website by website visitors. This enables us to find out, among other things, when which page views were made and from which region they come. We also collect various log files (e.g. IP address, referrer, browsers and operating systems used) and can measure whether our website visitors perform certain actions (e.g. clicks, purchases, etc.).
+
+The use of this analysis tool is based on Art. 6 para. 1 lit. f GDPR. The website operator has a legitimate interest in the anonymised analysis of user behaviour in order to optimise both its website and its advertising. If a corresponding consent has been requested, the processing is carried out exclusively on the basis of Art. 6 para. 1 lit. a GDPR and § 25 para. 1 TTDSG, insofar as the consent includes the storage of cookies or access to information in the user’s terminal device (e.g. device fingerprinting) within the meaning of the TTDSG. The consent can be revoked at any time.
+
+**IP anonymisation**
+
+We use IP anonymisation for the analysis with Matomo. This means that your IP address is shortened before analysis so that it can no longer be clearly assigned to you.
+
+If you do not agree to the storage and use of your data, you can deactivate the storage and use here. In this case, an opt-out cookie will be stored in your browser, which prevents Matomo from storing usage data. If you delete your cookies, this will have the effect that the Matomo opt-out cookie will also be deleted. The opt-out must be reactivated when you visit our site again.
+
+If you do not agree with the storage and use of your data, you can disable this feature here. In this case, an opt-out cookie will be stored in your browser to prevent Matomo from storing your usage data. If you delete your cookies, this will mean that the opt-out cookie will also be deleted. You will then need to reactivate it when you return to our site if you wish your activity not to be tracked.

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -40,7 +40,7 @@
 <div class="container">
      <div class="row">
       <div class="col-md-5 text-md-left text-center">
-       {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a> | <a href="about/privacy">Privacy</a> )</small></p> {{ end }}
+       {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a> | <a href="about/privacy">privacy</a> )</small></p> {{ end }}
       </div>
       <div class="col-md-2 text-md-left text-center">
         {{if .IsHome}}

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -1,10 +1,48 @@
+<div class="container fixed-bottom ">
+  <div class="m-2">
+      <div id="manage" class="mx-md-2 p-2 bg-white shadow-lg rounded d-none" data-c-view="manage"> <!--  -->
+          <h2>Manage Cookies</h2>
+          <p>We use cookies to provide and secure our website, as well as to analyze its usage, in order to offer the best user experience. You can modify your choice in any moment clicking on "Cookie preferences" button. 
+          </br> To learn more about our use of cookies see our <a href="policy.php">Privacy Policy</a>.</p>
+
+          <div class="my-3">
+              <div class="form-check">
+                  <input data-c-check="necessary" data-c-check-default="true" class="form-check-input" type="checkbox" value="" disabled="" id="necessary">
+                  <label class="form-check-label" for="necessary">
+                      Necessary. Mandatory cookies needed for basic site use
+                  </label>
+              </div>
+
+              <div class="form-check">
+                  <input data-c-check="analysis" data-c-check-default="true" class="form-check-input" type="checkbox" id="analysis">
+                  <label class="form-check-label" for="analysis">
+                      Site traffic analysis. Optional, needed for site access analysis tool
+                  </label>
+              </div>
+          </div>
+
+          <div class="d-flex">
+              <div data-c-action="accept" class="btn btn-warning flex-fill me-1">
+                  Accept
+              </div>
+              <div data-c-action="all" class="btn btn-primary flex-fill">
+                  All
+              </div>
+              <div data-c-action="necessary" class="btn btn-primary flex-fill ms-1">
+                  Necessary
+              </div>
+          </div>
+      </div>
+  </div>
+</div>
+
 <footer class="section bg-gray pb-0">
 <div class="container">
      <div class="row">
-      <div class="col-md-4 text-md-left text-center">
+      <div class="col-md-3 text-md-left text-center">
        {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a>)</small></p> {{ end }}
       </div>
-      <div class="col-md-4 text-md-left text-center">
+      <div class="col-md-2 text-md-left text-center">
         {{if .IsHome}}
         <p><small><a href="about/mirrors">Mirror sites</a></small></p>
         {{end}}
@@ -13,8 +51,13 @@
 	<p><small><a href="https://github.com/OSGeo/grass-website/tree/master/content/{{ .Section }}/{{ with .File }}{{ .BaseFileName }}{{ end }}.md" class="fa fa-github"> <span class="edt">Edit this page on GitHub</span></a></small></p>
   {{end}}
       </div>
+      <div class="col-md-3 text-md-right text-center">
+        <div class="widget widget-light">
+          <div id="open" class="btn btn-primary shadow p-1 rounded-pill" data-c-view="button">Cookie preferences</div>
+        </div>
+      </div>
       <div class="col-md-4 text-md-right text-center">	
-	<ul class="list-inline mb-3">
+	      <ul class="list-inline mb-3">
           {{ range .Site.Params.socialIcon }}
           <li class="list-inline-item"><a class="text-color d-inline-block p-2" href="{{ .link }}"><i class="{{ .icon }}"></i></a></li>
           {{ end }}
@@ -28,5 +71,11 @@
 <script>hljs.initHighlightingOnLoad();</script>
 <script src="{{ .Site.BaseURL }}plugins/gallery/photoswipe.js"></script>{{ $script := resources.Get "js/script.js" | minify}}
 <script src="{{ $script.Permalink }}"></script>
+<!-- this is for cookies -->
+<script type="module" src="{{ .Site.BaseURL }}plugins/cookies/cookify_loader.js"></script>
+<script type="text/javascript" data-c-script="analysis">
+    if (window.track) window.track()
+</script>
+
 </body>
 </html>

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -39,7 +39,7 @@
 <footer class="section bg-gray pb-0">
 <div class="container">
      <div class="row">
-      <div class="col-md-3 text-md-left text-center">
+      <div class="col-md-4 text-md-left text-center">
        {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a>)</small></p> {{ end }}
       </div>
       <div class="col-md-2 text-md-left text-center">
@@ -51,7 +51,7 @@
 	<p><small><a href="https://github.com/OSGeo/grass-website/tree/master/content/{{ .Section }}/{{ with .File }}{{ .BaseFileName }}{{ end }}.md" class="fa fa-github"> <span class="edt">Edit this page on GitHub</span></a></small></p>
   {{end}}
       </div>
-      <div class="col-md-3 text-md-right text-center">
+      <div class="col-md-2 text-md-right text-center">
         <div class="widget widget-light">
           <div id="open" class="btn btn-primary shadow p-1 rounded-pill" data-c-view="button">Cookie preferences</div>
         </div>

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -3,7 +3,7 @@
       <div id="manage" class="mx-md-2 p-2 bg-white shadow-lg rounded d-none" data-c-view="manage"> <!--  -->
           <h2>Manage Cookies</h2>
           <p>We use cookies to provide and secure our website, as well as to analyze its usage, in order to offer the best user experience. You can modify your choice in any moment clicking on "Cookie preferences" button. 
-          </br> To learn more about our use of cookies see our <a href="policy.php">Privacy Policy</a>.</p>
+          </br> To learn more about our use of cookies see our <a href="about/privacy">Privacy Policy</a>.</p>
 
           <div class="my-3">
               <div class="form-check">
@@ -39,8 +39,8 @@
 <footer class="section bg-gray pb-0">
 <div class="container">
      <div class="row">
-      <div class="col-md-4 text-md-left text-center">
-       {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a>)</small></p> {{ end }}
+      <div class="col-md-5 text-md-left text-center">
+       {{ with .Site.Params.copyright }} <p><small>&copy; {{ replace . "{year}" now.Year }} (<a href="/about/license/">license</a> | <a href="about/privacy">Privacy</a> )</small></p> {{ end }}
       </div>
       <div class="col-md-2 text-md-left text-center">
         {{if .IsHome}}

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -56,7 +56,7 @@
           <div id="open" class="btn btn-primary shadow p-1 rounded-pill" data-c-view="button">Cookie preferences</div>
         </div>
       </div>
-      <div class="col-md-4 text-md-right text-center">	
+      <div class="col-md-3 text-md-right text-center">	
 	      <ul class="list-inline mb-3">
           {{ range .Site.Params.socialIcon }}
           <li class="list-inline-item"><a class="text-color d-inline-block p-2" href="{{ .link }}"><i class="{{ .icon }}"></i></a></li>

--- a/themes/grass/layouts/partials/head.html
+++ b/themes/grass/layouts/partials/head.html
@@ -54,6 +54,21 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-config" content="{{ .Site.BaseURL }}images/favicon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//2022.foss4g.org/matomo/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '2']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>
 <body>
   <noscript>Please enable javascript :)</noscript>

--- a/themes/grass/layouts/partials/head.html
+++ b/themes/grass/layouts/partials/head.html
@@ -54,21 +54,6 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-config" content="{{ .Site.BaseURL }}images/favicon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
-  <!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="//2022.foss4g.org/matomo/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '2']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
 </head>
 <body>
   <noscript>Please enable javascript :)</noscript>

--- a/themes/grass/static/plugins/cookies/cookify.js
+++ b/themes/grass/static/plugins/cookies/cookify.js
@@ -1,0 +1,330 @@
+export default class Cookify {
+    constructor(dataName = 'cookify', actionCallback = () => {}, trackingCallback = () => {}, saveWithChange = false, saveByDefault = false, cookieDefault = 'necessary') {
+        this.dataName = dataName
+        this.data = new Object
+        this.query = 'data-c-'
+        this.trackingCallback = trackingCallback
+        this.saveByDefault = saveByDefault
+        this.saveWithChange = saveWithChange
+        this.cookieDefault = cookieDefault
+        this.viewedName = 'viewed'
+        this.actionCallback = actionCallback
+
+        this.init()
+    }
+
+    init() {
+        this.initData()
+
+        this.initCheckboxes()
+
+        this.initListeners()
+    }
+
+    /**
+     * Check the data for integrity
+     */
+    initData() {
+        if (!this.getMemoryData()) {
+            var typeElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check'))
+            
+            for (const typeElement of typeElements) {
+                if (typeElement.getAttribute(this.getQueryData('check')) == this.cookieDefault || typeElement.getAttribute(this.getQueryData('check-default')) == 'true') {
+                    this.data[typeElement.getAttribute(this.getQueryData('check'))] = true
+                } else {
+                    this.data[typeElement.getAttribute(this.getQueryData('check'))] = false
+                }
+            }
+
+            this.data[this.viewedName] = false
+            this.saveByDefault ? this.setMemoryData(this.data) : null
+        } else {
+            this.data = this.getMemoryData()
+        }
+    }
+
+    /**
+     * Initialize the checkboxes
+     */
+    initCheckboxes() {
+        var typeElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check')),
+            checkChecked = new Array
+
+        for (const typeElement of typeElements) {
+            var type = typeElement.getAttribute(this.getQueryData('check'))
+
+            if (this.getDataState(type)) {
+                var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type))
+
+                for (const checkboxElement of checkboxElements) {
+                    checkboxElement.checked = 'checked'
+
+                    if (type == this.cookieDefault) {
+                        checkboxElement.disabled = true
+                    }
+                }
+
+                !checkChecked[type] && this.changeScriptType(type, 'js')
+                checkChecked[type] = true
+            }
+        }
+    }
+
+    /**
+     * Initialize the Listeners
+     */
+    initListeners() {
+        // Checkboxes
+        var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check'))
+
+        for (const checkboxElement of checkboxElements) {
+            checkboxElement.addEventListener('click', this.onCheckboxClick)
+        }
+
+        // Actions
+        var actionElements = document.querySelectorAll(this.getQueryDataBrackets('action'))
+
+        for (const actionElement of actionElements) {
+            switch (actionElement.getAttribute(this.getQueryData('action'))) {
+                case 'accept':
+                    actionElement.addEventListener('click', this.onActionAcceptClick)
+                    break;
+
+                case 'necessary':
+                    actionElement.addEventListener('click', this.onActionNecessaryClick)
+                    break;
+
+                case 'all':
+                    actionElement.addEventListener('click', this.onActionAllClick)
+                    break;
+            
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Get the query name for selecting elements
+     * 
+     * @param {string} type 
+     * @param {string} element 
+     * @returns {string}
+     */
+    getQueryData(type, element = '') {
+        return element == '' ? `${this.query}${type}` : `${this.query}${type}="${element}"`
+    }
+
+    /**
+     * Get the query name with brackets for selecting elements
+     * 
+     * @param {string} type 
+     * @param {string} element 
+     * @returns {string}
+     */
+    getQueryDataBrackets(type, element = '') {
+        return '[' + this.getQueryData(type, element) + ']'
+    }
+
+    /**
+     * Read the saved data
+     * 
+     * @returns data
+     */
+    getMemoryData() {
+        // Get from Cookies
+        var name = this.dataName + '=',
+            ca = document.cookie.split(';')
+
+        for(var i = 0; i < ca.length; i++) {
+            var c = ca[i]
+
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return JSON.parse(atob(c.substring(name.length, c.length)))
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Set the data
+     * 
+     * @param data
+     */
+    setMemoryData(data) {
+        // Callback for tracking user activity
+        this.trackingCallback([
+            data,
+            new Date()
+        ])
+
+        // Verschlüsselung
+        data = btoa(JSON.stringify(data))
+
+        // Save in cookies
+        var date = new Date(),
+            expire = 365,
+            expires = ''
+
+        date.setTime(date.getTime() + (expire * 24 * 60 * 60 * 1000))
+        expires = 'expires=' + date.toUTCString()
+        document.cookie = this.dataName + '=' + data + ';' + expires + ';path=/;SameSite=Lax' //';path=/;secure'
+    }
+
+    /**
+     * Get a cookie state
+     * 
+     * @param {string} type 
+     */
+    getDataState(type) {
+        for (const key in this.data) {
+            if (key == type) {
+                return this.data[key] === true
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Changes the cookie state and saves the data
+     * 
+     * @param {string} type 
+     * @param {boolean} value 
+     * @returns {boolean} 
+     */
+    changeDataState(type, value) {
+        for (const key in this.data) {
+            if (key == type) {
+                this.data[key] = value
+            }
+        }
+
+        this.saveWithChange ? this.setMemoryData(this.data) : null
+
+        // Call Event to let the user track activity
+        return value
+    }
+
+    /**
+     * Any Script type can be changed from text/plain
+     * and text/javascript and back
+     * 
+     * @param {string} script 
+     * @param {string} type 
+     */
+    changeScriptType(script, type) {
+        var scriptElements = document.querySelectorAll('script' + this.getQueryDataBrackets('script'))
+
+        for (const scriptElement of scriptElements) {
+            if (scriptElement.getAttribute(this.getQueryData('script')) == script) {
+                if (type == 'js') {
+                    var reloadScriptElement = document.createElement('script'),
+                        parentScriptElement = scriptElement.parentNode
+
+                    for (const key in scriptElement.attributes) {
+                        if (scriptElement.attributes[key].value) {
+                            const attribute = scriptElement.attributes[key]
+                            
+                            reloadScriptElement.setAttribute(attribute.name, attribute.value)
+                        }
+                    }
+
+                    reloadScriptElement.setAttribute('type', 'text/javascript')
+                    reloadScriptElement.innerHTML = scriptElement.innerHTML
+
+                    scriptElement.remove()
+                    parentScriptElement.appendChild(reloadScriptElement)
+                } else {
+                    scriptElement.setAttribute('type', 'text/plain')
+                }
+            }
+        }
+    }
+
+    /**
+     * Event Listeners
+     */
+
+    /**
+     * Event on mouse click
+     * 
+     * @param {event} e 
+     */
+    onCheckboxClick = e => {
+        var type = e.target.getAttribute(this.getQueryData('check')),
+            checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type)),
+            cookieState = this.getDataState(type)
+
+        cookieState = this.changeDataState(type, !cookieState)
+        this.saveWithChange && (cookieState ? this.changeScriptType(type, 'js') : this.changeScriptType(type, 'plain'))
+
+        for (const checkboxElement of checkboxElements) {
+            cookieState ? checkboxElement.checked = 'checked' : checkboxElement.checked = false
+        }
+    }
+
+    /**
+     * Event on action accept click
+     */
+    onActionAcceptClick = () => {
+        for (const type in this.data) {
+            if (type != this.viewedName) {
+                this.data[type] ? this.changeScriptType(type, 'js') : this.changeScriptType(type, 'plain')
+            }
+        }
+        
+        this.data[this.viewedName] = true
+        this.setMemoryData(this.data)
+        this.actionCallback()
+    }
+
+    /**
+     * Event action accept only necessary click
+     */
+    onActionNecessaryClick = () => {
+        // Nur notwendig auf true
+        for (const type in this.data) {
+            if (type != this.cookieDefault && type != this.viewedName) {
+                this.data[type] = false
+                this.changeScriptType(type, 'plain')
+
+                var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type))
+
+                for (const checkboxElement of checkboxElements) {
+                    checkboxElement.checked = false
+                }
+            }
+        }
+
+        this.data[this.viewedName] = true
+        this.setMemoryData(this.data)
+        this.actionCallback()
+    }
+
+    /**
+     * Event action accept all cick
+     */
+    onActionAllClick = () => {
+        for (const type in this.data) {
+            this.data[type] = true
+
+            if (type != this.viewedName) {
+                this.changeScriptType(type, 'js')
+
+                var checkboxElements = document.querySelectorAll('input' + this.getQueryDataBrackets('check', type))
+
+                for (const checkboxElement of checkboxElements) {
+                    checkboxElement.checked = 'checked'
+                }
+            }
+        }
+
+        this.setMemoryData(this.data)
+        this.actionCallback()
+    }
+}

--- a/themes/grass/static/plugins/cookies/cookify_loader.js
+++ b/themes/grass/static/plugins/cookies/cookify_loader.js
@@ -1,0 +1,24 @@
+import Cookify from './cookify.js'
+import track from './track.js'
+
+var cookify = new Cookify('cookie_consent', function () {
+    document.getElementById('manage').classList.add('d-none')
+}, function (data) {
+    console.log(data)
+}, false, false, 'necessary')
+
+window.cookify = cookify
+window.track = track
+
+document.getElementById('open').addEventListener('click', function () {
+    document.getElementById('manage').classList.remove('d-none')
+})
+
+if (!cookify.getDataState(cookify.viewedName)) {
+    document.getElementById('manage').classList.remove('d-none')
+}
+
+console.log("necessary",cookify.getDataState('necessary'))
+console.log("analysis",cookify.getDataState('analysis'))
+
+track()

--- a/themes/grass/static/plugins/cookies/track.js
+++ b/themes/grass/static/plugins/cookies/track.js
@@ -3,6 +3,8 @@ export default function track() {
 	  console.log("Stat tracking enabled");
 	  var _paq = window._paq = window._paq || [];
 	  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+	  /* Call disableCookies before calling trackPageView */
+	  _paq.push(['disableCookies']);
 	  _paq.push(['trackPageView']);
 	  _paq.push(['enableLinkTracking']);
 	  (function() {

--- a/themes/grass/static/plugins/cookies/track.js
+++ b/themes/grass/static/plugins/cookies/track.js
@@ -1,0 +1,18 @@
+export default function track() {
+	if (window.cookify && window.cookify.getDataState('analysis')) {
+	  console.log("Stat tracking enabled");
+	  var _paq = window._paq = window._paq || [];
+	  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+	  _paq.push(['trackPageView']);
+	  _paq.push(['enableLinkTracking']);
+	  (function() {
+		var u="https://2022.foss4g.org/matomo/";
+		_paq.push(['setTrackerUrl', u+'matomo.php']);
+		_paq.push(['setSiteId', '1']);
+		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+		g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+	  })();
+	} else {
+		console.log("Stat tracking disabled");
+	}
+}


### PR DESCRIPTION
To know more about Web accesses on https://grass.osgeo.org/ and download stats, this PR adds the needed matomo code (https://matomo.org/).

See:
- https://lists.osgeo.org/pipermail/sac/2022-October/014745.html
- https://lists.osgeo.org/pipermail/sac/2022-October/014747.html

@lucadelu kindly created a new matomo for GRASS GIS and me as an initial user. The instance is hosted by GFOSS.it at https://2022.foss4g.org/matomo/