### PR TITLE
404 page: add a few more links

### DIFF
--- a/themes/grass/layouts/404.html
+++ b/themes/grass/layouts/404.html
@@ -9,7 +9,7 @@
           <h1><a href="{{ "/" | relURL }}"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="33%"></a></h1>
 	  <div class="alert alert-warning"><h2 style="margin:10px;color:red;">Sorry, there's nothing here.<span style="display:block;margin:10px;font-size:.75em;">
              <a href="{{ "/" | relURL }}"><i class="fa fa-home"></i> home</a><br>
-             <a href="{{ "/learn/manuals/" | relURL }}"><i class="fa fa-home"></i> manuals</a><br>
+             <a href="{{ "/learn/manuals/" | relURL }}"><i class="fa fa-file-text"></i> manuals</a><br>
              <a href="{{ "/download/" | relURL }}"><i class="fa fa-home"></i> downloads</a>
            </h2>
           </div>

--- a/themes/grass/layouts/404.html
+++ b/themes/grass/layouts/404.html
@@ -7,10 +7,14 @@
       <div class="row">
         <div class="col-lg-8 text-center mx-auto">
           <h1><a href="{{ "/" | relURL }}"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="33%"></a></h1>
-	<div class="alert alert-warning"><h2 style="margin:10px;color:red;">Sorry, there's nothing here.<span style="display:block;margin:10px;font-size:.75em;"><a href="{{ "/" | relURL }}"><i class="fa fa-home"></i> home</a></h2></div>
+	  <div class="alert alert-warning"><h2 style="margin:10px;color:red;">Sorry, there's nothing here.<span style="display:block;margin:10px;font-size:.75em;">
+             <a href="{{ "/" | relURL }}"><i class="fa fa-home"></i> home</a><br>
+             <a href="{{ "/learn/manuals/" | relURL }}"><i class="fa fa-home"></i> manuals</a><br>
+             <a href="{{ "/download/" | relURL }}"><i class="fa fa-home"></i> downloads</a>
+           </h2>
+          </div>
         </div>
       </div>
     </div>
-    </header>
-
+  </header>
 {{ partial "footer.html" . }}

--- a/themes/grass/layouts/404.html
+++ b/themes/grass/layouts/404.html
@@ -10,7 +10,7 @@
 	  <div class="alert alert-warning"><h2 style="margin:10px;color:red;">Sorry, there's nothing here.<span style="display:block;margin:10px;font-size:.75em;">
              <a href="{{ "/" | relURL }}"><i class="fa fa-home"></i> home</a><br>
              <a href="{{ "/learn/manuals/" | relURL }}"><i class="fa fa-file-text"></i> manuals</a><br>
-             <a href="{{ "/download/" | relURL }}"><i class="fa fa-home"></i> downloads</a>
+             <a href="{{ "/download/" | relURL }}"><i class="fa fa-download"></i> downloads</a>
            </h2>
           </div>
         </div>


### PR DESCRIPTION
Looking at recent matomo stats showed that users do not necessarily use the top menu to find stuff. Hence addition of a few core links on the "404 page not found" page.

TODO: find the appropriate "fa" icons.

With this PR it looks like this (added "manuals" and "downloads"):

![image](https://user-images.githubusercontent.com/1295172/205882246-9f14a01d-c11e-4d69-827d-90a2d3eb7eee.png)
