### PR TITLE
Mastodon icon and site verification

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -245,6 +245,10 @@ greyColorDark = "#A0A0A0"
           link = "https://gitter.im/grassgis/community"
 
     [[Languages.en.socialIcon]]
+      icon = " fa fa-mastodon"
+      link = "https://fosstodon.org/@grassgis"
+
+    [[Languages.en.socialIcon]]
       icon = " fa fa-twitter"
       link = "https://twitter.com/grassgis"    
 

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -6,7 +6,9 @@
       </div>
       <div class="col-md-4 text-md-left text-center">
         {{if .IsHome}}
-        <p><small><a href="about/mirrors">Mirror sites</a></small></p>
+        <p><small><a href="about/mirrors">Mirror sites</a>
+        <a href="https://fosstodon.org/@grassgis" rel="me"></a> <!-- needed for verification -->
+        </small></p>
         {{end}}
 
 	{{if not .IsHome}}


### PR DESCRIPTION
This PR adds

- the Mastodon icon in the footer, next to Twitter (ok, it actually doesn't show up, why?)
- adds verification in the Mastodon profile (follows https://docs.joinmastodon.org/user/profile/#verification) with an invisible `rel="me"` link

## Mastodon Icon "there" but not visible, what's missing?

![image](https://user-images.githubusercontent.com/1295172/208202750-61f9899e-6e64-4155-b533-331075547c89.png)


## Fosstodon profile with web site highlighted in green, looks fine:

![image](https://user-images.githubusercontent.com/1295172/208202604-f1dafb39-2f2d-4bff-8f6a-573a363a4cca.png)
