### PR TITLE
Add .hugo_build.lock and hugo.exe file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ resources/
 
 # Temporary lock file while building
 /.hugo_build.lock
+
+# Ignore the Windows Hugo executable
+hugo.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 public/
 resources/
+
+# Temporary lock file while building
+/.hugo_build.lock


### PR DESCRIPTION
To help out newcomers when running `hugo server` locally, this prevents showing that this is a new file that would be added to the repository.

It's not much, but it was a common commit I was doing when exploring how to make contributing easier in the repo.