### PR TITLE
Fixed broken links for manual pages

### DIFF
--- a/content/learn/_index.en.md
+++ b/content/learn/_index.en.md
@@ -11,7 +11,7 @@ weight: 2
 <h3 class="mt-2 mb-4">Plenty of resources</h3>
 
 There are plenty of resources online to get started and learn GRASS GIS: from 
-[manual pages](/learn/manuals) for each module and addon with examples, 
+[manual pages](https://grass.osgeo.org/learn/manuals/) for each module and addon with examples, 
 [wiki](https://grasswiki.osgeo.org/wiki/GRASS-Wiki) pages with applications 
 and use cases to beginner and advanced [courses and workshops](/learn/tutorials), 
 videos and presentations for specific topics, 


### PR DESCRIPTION
I was opening manual pages, but it was giving me error. So I have tried to fix it