### PR TITLE
404.html: advertise the current GRASS GIS version

### DIFF
--- a/themes/grass/layouts/404.html
+++ b/themes/grass/layouts/404.html
@@ -7,11 +7,14 @@
       <div class="row">
         <div class="col-lg-8 text-center mx-auto">
           <h1><a href="{{ "/" | relURL }}"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="33%"></a></h1>
-	  <div class="alert alert-warning"><h2 style="margin:10px;color:red;">Sorry, there's nothing here.<span style="display:block;margin:10px;font-size:.75em;">
+          <div class="alert alert-warning">
+           <h2 style="margin:10px;color:red;">Sorry, there's nothing here.
+             <span style="display:block;margin:10px;font-size:.75em;">
              <a href="{{ "/" | relURL }}"><i class="fa fa-home"></i> home</a><br>
              <a href="{{ "/learn/manuals/" | relURL }}"><i class="fa fa-file-text"></i> manuals</a><br>
              <a href="{{ "/download/" | relURL }}"><i class="fa fa-download"></i> downloads</a>
            </h2>
+           <p style="color: #088B36;">Current version: GRASS GIS {{ .Site.Data.grass.current_version }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Aim: reduce confusion when visitors land on an outdated version announcement (problem identified with Matomo, search behaviour analysis). At least, now they know what to look for....

Shortcode from: https://github.com/OSGeo/grass-website/tree/master/themes/grass/layouts/shortcodes

## old
![image](https://user-images.githubusercontent.com/1295172/216816013-1ae19265-8277-49bb-8fd3-7cebc2f32146.png)

## new
![image](https://user-images.githubusercontent.com/1295172/216816022-d98c93b4-47ac-4e8f-b480-8475eb92a2f6.png)


Fixes #351