### PR TITLE
download/linux: add packaging status button

### DIFF
--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -12,9 +12,11 @@ layout: "os"
 
 <hr>
 
-Install <tt>grass</tt> package on your Linux distribution. See also
-{{< donateDialog isToggle=true isMarkdown=true >}}[Repology](https://repology.org/project/grass/versions){{< /donateDialog  >}} for extended
-list of GRASS GIS packages.
+Install <tt>grass</tt> package on your Linux distribution. Have a look at 
+{{< donateDialog isToggle=true isMarkdown=true >}}[Repology](https://repology.org/project/grass/versions){{< /donateDialog  >}} for an extended
+list of GRASS GIS packages or directly check the 
+<a href="https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion=8.2.0&columns=3" class="btn btn-primary">Packaging Status</a>
+to quickly know which GRASS GIS version is currently available for your distro.
 
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[Arch Linux](https://aur.archlinux.org/packages/grass/){{< /donateDialog  >}}
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[Debian](https://packages.debian.org/grass){{< /donateDialog  >}}

--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -10,9 +10,7 @@ layout: "os"
 
 [ [**GRASS GIS {{< grassVersion version="current" type="short">}} (current)**](#GRASS-GIS-current) | [**GRASS {{< grassVersion version="legacy" type="short">}} (legacy)**](#GRASS-GIS-old) | [**GRASS {{< grassVersion version="preview" type="short">}} (preview)**](#GRASS-GIS-devel) ]
 
-<hr>
-
-Install <tt>grass</tt> package on your Linux distribution. Have a look at 
+<i class="fa fa-arrow-right"></i> Install <tt>grass</tt> package on your Linux distribution. Have a look at 
 {{< donateDialog isToggle=true isMarkdown=true >}}[Repology](https://repology.org/project/grass/versions){{< /donateDialog  >}} for an extended
 list of GRASS GIS packages or directly check the 
 <a href="https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion=8.2.0&columns=3" class="btn btn-primary">Packaging Status</a>
@@ -26,6 +24,8 @@ to quickly know which GRASS GIS version is currently available for your distro.
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[Mageia](https://madb.mageia.org/package/show/name/grass/){{< /donateDialog  >}}
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[openSUSE](https://build.opensuse.org/package/show/Application:Geo/grass){{< /donateDialog  >}}
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable){{< /donateDialog  >}} (ubuntugis-unstable)
+
+<hr>
 
 ### <span id="GRASS-GIS-current"> GRASS GIS {{< grassVersion version="current" >}} (current)</span>
 

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -15,11 +15,10 @@ layout: "os"
  {{< donateDialog isToggle=true >}}  
      <a href="http://grassmac.wikidot.com" target="_blank"> GRASS GIS for the Mac </a> 
  {{< /donateDialog  >}} 
-or install the latest available version from <a href="https://ports.macports.org/port/grass/"  target="_blank">Macports</a>
-<a href="https://repology.org/project/grass/versions">
+or install the latest available version from <a href="https://ports.macports.org/port/grass/" target="_blank">MacPorts</a> 
+<a href="https://repology.org/project/grass/versions" target="_blank"> 
   <img src="https://repology.org/badge/version-for-repo/macports/grass.svg" alt="MacPorts package">
 </a>
-
 </div>
 
 <hr>

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -17,7 +17,7 @@ layout: "os"
  {{< /donateDialog  >}} 
 or install the latest available version from <a href="https://ports.macports.org/port/grass/" target="_blank">MacPorts</a> 
 <a href="https://repology.org/project/grass/versions" target="_blank"> 
-  <img src="https://repology.org/badge/version-for-repo/macports/grass.svg" alt="MacPorts package">
+  <img class="inl" src="https://repology.org/badge/version-for-repo/macports/grass.svg" alt="MacPorts package">
 </a>
 </div>
 

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -11,10 +11,14 @@ layout: "os"
 [ [**GRASS GIS {{< grassVersion version="current" type="short">}} (current)**](#GRASS-GIS-current) | [**GRASS {{< grassVersion version="legacy" type="short">}} (legacy)**](#GRASS-GIS-old) | [**GRASS {{< grassVersion version="preview" type="short">}} (preview)**](#GRASS-GIS-devel) ]
 
 <div class="alert rounded-0 alert-default">
-<i class="fa fa-arrow-right"></i> Find <b>GRASS GIS binaries</b> on this website:
+<i class="fa fa-arrow-right"></i> Find <b>GRASS GIS binaries</b> on
  {{< donateDialog isToggle=true >}}  
      <a href="http://grassmac.wikidot.com" target="_blank"> GRASS GIS for the Mac </a> 
  {{< /donateDialog  >}} 
+or install the latest available version from <a href="https://ports.macports.org/port/grass/"  target="_blank">Macports</a>
+<a href="https://repology.org/project/grass/versions">
+  <img src="https://repology.org/badge/version-for-repo/macports/grass.svg" alt="MacPorts package">
+</a>
 
 </div>
 
@@ -36,9 +40,8 @@ layout: "os"
 <ul>
 <li>
  {{< donateDialog isToggle=true >}}  
-<a href="https://ports.macports.org/port/grass/"></i>MacPorts</a>
- {{< /donateDialog  >}} 
- 
+<a href="https://ports.macports.org/port/grass/">MacPorts</a>
+ {{< /donateDialog  >}}
 </li>
 </ul>
 

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -791,6 +791,11 @@ img {
   height: auto;
   margin-bottom: 15px;
 }
+
+a.ext img.inl {
+    margin-bottom:0px;
+}
+
 ul {
   padding: 0;
   margin: 0 0 20px 20px;


### PR DESCRIPTION
I added a button with the packaging status from Repology as was originally suggested in https://github.com/OSGeo/grass/pull/2703.

I put the button within the Linux page as I didn't find the way to filter out BSD and MacPorts, and I do not see where to put such a button in Downloads main page. This is how it looks for now: 
 
![image](https://user-images.githubusercontent.com/20075188/220438858-0570ccc6-f314-4f26-bb2b-f0f22db69fb7.png)
