### PR TITLE
Donation links: Point to different contribution options page

### DIFF
--- a/content/contribute/sponsoring.md
+++ b/content/contribute/sponsoring.md
@@ -18,7 +18,7 @@ There is no cost to participate in the project itself or to use the software.
 But with our own budget we can produce even better software and documentation for you.
 And if you don't have time to contribute, maybe a (small) donation makes you feel better when using GRASS GIS.
 
-<div align="center"><button class="btn btn-primary"><b><a href="https://opencollective.com/grass" target="_blank">SUPPORT GRASS GIS</a></b></button></div>
+<div align="center"><button class="btn btn-primary"><b><a href="https://opencollective.com/grass/contribute" target="_blank">SUPPORT GRASS GIS</a></b></button></div>
 
 ### How we use the money
 

--- a/themes/grass/layouts/shortcodes/donateDialog.html
+++ b/themes/grass/layouts/shortcodes/donateDialog.html
@@ -26,7 +26,7 @@
             While downloading your <em>free</em> and <em>open source</em> copy of <strong>GRASS GIS</strong>, if you or your 
             institution enjoy the software 
             please consider making a  
-            <a href="https://opencollective.com/osgeo/projects/grass/donate">
+            <a href="https://opencollective.com/osgeo/projects/grass/contribute">
               <strong>
                 donation to support the project</strong></a>.
              May the FOSS be with you!
@@ -41,7 +41,7 @@
             </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          <a   class="btn btn-primary-active" href="https://opencollective.com/osgeo/projects/grass/donate">Donate</a>
+          <a   class="btn btn-primary-active" href="https://opencollective.com/osgeo/projects/grass/contribute">Donate</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
We have created different sponsor tiers in Opencollective and hence, this PR changes the donation links to https://opencollective.com/osgeo/projects/grass/contribute so potential donor can choose from them