### PR TITLE
News: add FOSS4G 2023 event

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ If the md file used for generating the page has a summary, its value is used as 
 
   title: "CONFERENCE NAME"
   event:
-      start: START-DATE
-      end: END-DATE
-  where: CITY
+      start: YYYY-MM-DD
+      end: YYYY-MM-DD
+  where: CITY, COUNTRY
   website: URL
   layout: "event"
-  logo: images/conferences_logos/YOUR_LOGO.png
+  logo: images/conferences_logos/CONF_LOGO_YEAR.png
 
 
 * Add your logo to `/grass-website/images/conferences_logos` folder

--- a/content/events/FOSS4G_2022.md
+++ b/content/events/FOSS4G_2022.md
@@ -1,0 +1,12 @@
+---
+title: "FOSS4G 2022"
+event:
+    start: 2022-08-22
+    end: 2023-08-28
+where: Firenze, Italy
+website: https://2022.foss4g.org
+layout: "event"
+author: Admin
+logo: images/conferences_logos/foss4g_2022.svg
+---
+

--- a/content/events/FOSS4G_2023.md
+++ b/content/events/FOSS4G_2023.md
@@ -1,0 +1,12 @@
+---
+title: "FOSS4G 2023"
+event:
+    start: 2023-06-23
+    end: 2023-07-02
+where: Prizren, Kosovo
+website: https://2023.foss4g.org
+layout: "event"
+author: Admin
+logo: images/conferences_logos/foss4g_2023_logo.png
+---
+


### PR DESCRIPTION
- add FOSS4G 2023
- also add missing FOSS4G 2022 (for posterity)
- clarify date format in README.md

Screenshot:
![image](https://github.com/OSGeo/grass-website/assets/1295172/7cb1c18b-2fd7-4b69-8088-169853515a2e)
