### PR TITLE
fix FOSS4G link -> 2023

### DIFF
--- a/themes/grass/layouts/partials/foss4g.html
+++ b/themes/grass/layouts/partials/foss4g.html
@@ -1,4 +1,4 @@
-<a href="https://2022.foss4g.org/" target="_blank" class="px-4 py-5 bg-gray text-center shadow d-block fdiv">
+<a href="https://2023.foss4g.org/" target="_blank" class="px-4 py-5 bg-gray text-center shadow d-block fdiv">
    <img src="{{ .Site.BaseURL }}/images/conferences_logos/foss4g_2023_logo.png" width="64%"/>
    <p class="mt-3 mb-0">Meet the GRASS GIS community at the next geospatial event</p>
 </a>


### PR DESCRIPTION
FOSS4G widget points to year 2022

![image](https://github.com/OSGeo/grass-website/assets/5683186/f324e9d7-744f-413b-ad83-a670381d1538)
