### PR TITLE
Set fixed position of banner and navbar element during page scrolling

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -801,7 +801,7 @@ ul {
   margin: 0 0 20px 20px;
 }
 ul li a {
-  display: inline-block; 
+  display: inline-block;
   font-size: 15px;
   font-weight: 400;
   padding: 2px 0px;
@@ -980,7 +980,7 @@ li.parent a {
     background: #F6F6F6;
   }
 
-  
+
   .timeline .panel {
     position: relative;
     margin: 10px 0px 0px 40px;
@@ -1090,7 +1090,7 @@ li.parent a {
     display:block;
 }
 
-.timeline .glyphicon.glyphicon-one-fine-dot:before {   
+.timeline .glyphicon.glyphicon-one-fine-dot:before {
   content: "\25cf";
   font-size: 1.5em;
   color: #0039a6;
@@ -1189,7 +1189,7 @@ nobullets {
    list-style-type: none;
 }
 
-  /* 
+  /*
 
 .hljs {
    background:#c5c8c6;
@@ -1272,6 +1272,9 @@ code{
     margin-left:-59px;
     z-index:1;
 }
+.mt-95 {
+    margin-top: 95px;
+}
 
 
 @media (max-width: 576px) {
@@ -1296,7 +1299,7 @@ code{
   font-size: 28px !important;
   }
   h2, .h2 {
-  font-size: 24px !important;    
+  font-size: 24px !important;
   }
   h3, .h3 {
   font-size: 22px !important;
@@ -1331,7 +1334,7 @@ code{
     padding-top: 20px;
     padding-bottom: 20px;
    }
-  
+
   .section-title {
     margin-bottom: 32px;
     font-size: 22px !important;
@@ -1345,7 +1348,7 @@ code{
   }
 
   #links li span a {
-    font-size: 15px !important;      
+    font-size: 15px !important;
   }
   .entry-meta {
     font-size: 14px !important;

--- a/themes/grass/layouts/_default/list.html
+++ b/themes/grass/layouts/_default/list.html
@@ -1,10 +1,12 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
   {{ "<!-- /navigation -->" | safeHTML }}
@@ -22,7 +24,7 @@
 <!-- /page title -->
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-3">

--- a/themes/grass/layouts/_default/list.html
+++ b/themes/grass/layouts/_default/list.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/_default/single.html
+++ b/themes/grass/layouts/_default/single.html
@@ -2,15 +2,17 @@
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single pt-5 bg-gray">
+<section class="single pt-5 bg-gray mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-4">
@@ -23,7 +25,7 @@
                 {{- end -}}
               </ul>
             </nav>
-    
+
             {{define "menu"}}
             {{- $currentNode := .currentnode -}}
             {{ with .sect }}
@@ -72,11 +74,11 @@
             <a class="nav nav-next" href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}<i class="fa fa-arrow-right  ml-2"></i></a>
             {{- end }}
             </nav>
-    
+
             {{- define "pagination" -}}
             {{- $currentNode := .currentnode -}}
             {{- $menu_exclusion := .menu_exclusion -}}
-    
+
             {{- if hasPrefix $currentNode.Permalink .menu.Permalink -}}
               {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
               {{- if .menu.IsHome -}}
@@ -93,7 +95,7 @@
                 {{- end -}}
               {{- end -}}
             {{- end -}}
-    
+
             {{- $currentNode.Scratch.Set "prevPageTmp" .menu -}}
             {{- $currentNode.Scratch.Set "pages" .menu.Pages -}}
             {{- if .menu.IsHome -}}

--- a/themes/grass/layouts/_default/single.html
+++ b/themes/grass/layouts/_default/single.html
@@ -3,8 +3,10 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/about/brand.html
+++ b/themes/grass/layouts/about/brand.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/about/brand.html
+++ b/themes/grass/layouts/about/brand.html
@@ -1,18 +1,20 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/about/community.html
+++ b/themes/grass/layouts/about/community.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/about/community.html
+++ b/themes/grass/layouts/about/community.html
@@ -1,11 +1,13 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -13,7 +15,7 @@
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-8">
@@ -28,7 +30,7 @@
 	<img src="/images/gallery/community/2017_grass-devteam_paris.jpg" alt="GRASS GIS dev team">
 	<label class="nm"><small><i>Some of the GRASS dev team members</i></small></label>
 	</figure>
-      <div class="mt-20">	
+      <div class="mt-20">
 	{{ partial "wiki.html" . }}
       <div class="mt-30">
 	{{ partial "osgeo.html" . }}

--- a/themes/grass/layouts/about/credits.html
+++ b/themes/grass/layouts/about/credits.html
@@ -1,19 +1,21 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
-</header>
+/header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-8">

--- a/themes/grass/layouts/about/credits.html
+++ b/themes/grass/layouts/about/credits.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 /header>

--- a/themes/grass/layouts/about/general.html
+++ b/themes/grass/layouts/about/general.html
@@ -1,20 +1,22 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
-</header>
+/header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/about/general.html
+++ b/themes/grass/layouts/about/general.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 /header>

--- a/themes/grass/layouts/about/list.html
+++ b/themes/grass/layouts/about/list.html
@@ -15,7 +15,7 @@
 
 
     <section>
-      <section class="pt-4 bg-gray">
+      <section class="pt-4 bg-gray mt-95">
         <div class="container">
           <div class="row">
             <div class="col-12 text-center">

--- a/themes/grass/layouts/about/list.html
+++ b/themes/grass/layouts/about/list.html
@@ -1,10 +1,14 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -24,7 +28,7 @@
             <div class="col-12 bg-white mb-4">
               The Geographic Resources Analysis Support System (<a href="https://grass.osgeo.org/" target="_blank">https://grass.osgeo.org/</a>),
               commonly referred to as GRASS GIS, is an Open Source Geographic Information System providing powerful raster, vector and geospatial
-              processing capabilities. It can be used either as a stand-alone application or as backend for other software packages such as 
+              processing capabilities. It can be used either as a stand-alone application or as backend for other software packages such as
               <a href="https://qgis.org" target="_blank">QGIS</a> and <a href="https://www.r-project.org/" target="_blank">R</a>
               or in the cloud. It is distributed freely under the terms of the GNU General Public License (GPL).
               GRASS GIS is a founding member of the Open Source Geospatial Foundation (<a href="https://www.osgeo.org" target="_blank">OSGeo</a>).
@@ -34,7 +38,7 @@
         <div class="container">
           <div class="row">
             <div class="col-lg-12">
-	      {{ range where .Pages "File.Dir" "in" "/about/" }}   
+	      {{ range where .Pages "File.Dir" "in" "/about/" }}
               <div class="section bg-white mb-4">
                 <div class="row nm">
                   <div class="col-1 text-center"><i class="fa fa-file-text-o fa-3x grey-color-light"></i></div>
@@ -43,7 +47,7 @@
                   </div>
                 </div>
 		</div>
-	       {{ end }}  
+	       {{ end }}
             </div>
           </div>
         </div>

--- a/themes/grass/layouts/about/theme.html
+++ b/themes/grass/layouts/about/theme.html
@@ -2,17 +2,20 @@
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
-  </div>
+  <div class="fixed-top">
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
-    
+
  <section class="elements pt-5 bg-gray">
  <div class="container">
     <div class="row">
- 
+
       <div class="col-lg-12">
       <div class="p-5 bg-white">
 	      {{ .Content }}

--- a/themes/grass/layouts/about/timeline.html
+++ b/themes/grass/layouts/about/timeline.html
@@ -3,17 +3,17 @@
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-
-
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-8 col-sm-12">

--- a/themes/grass/layouts/about/timeline.html
+++ b/themes/grass/layouts/about/timeline.html
@@ -4,8 +4,10 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/contribute/contribute.html
+++ b/themes/grass/layouts/contribute/contribute.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/contribute/contribute.html
+++ b/themes/grass/layouts/contribute/contribute.html
@@ -1,16 +1,18 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-  <section class="single section bg-gray pb-0">
+  <section class="single section bg-gray pb-0 mt-5">
     <div class="container">
       <div class="row">
         <div class="col-lg-4">
@@ -44,5 +46,5 @@
       </div>
     </div>
     </section>
-    
+
   {{ partial "footer.html" . }}

--- a/themes/grass/layouts/contribute/devel.html
+++ b/themes/grass/layouts/contribute/devel.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/contribute/devel.html
+++ b/themes/grass/layouts/contribute/devel.html
@@ -1,17 +1,19 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-  <section class="single section bg-gray pb-0">
+  <section class="single section bg-gray pb-0 mt-5">
     <div class="container">
       <div class="row">
         <div class="col-lg-8">
@@ -43,5 +45,5 @@
       </div>
     </div>
     </section>
-    
+
   {{ partial "footer.html" . }}

--- a/themes/grass/layouts/contribute/general.html
+++ b/themes/grass/layouts/contribute/general.html
@@ -1,17 +1,19 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/contribute/general.html
+++ b/themes/grass/layouts/contribute/general.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/contribute/list.html
+++ b/themes/grass/layouts/contribute/list.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/contribute/list.html
+++ b/themes/grass/layouts/contribute/list.html
@@ -1,10 +1,12 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -12,7 +14,7 @@
 
 
 <!-- details page -->
-<section class="pt-4 bg-gray">
+<section class="pt-4 bg-gray mt-5">
   <div class="container">
   <div class="row">
         <div class="col-12 text-center">

--- a/themes/grass/layouts/contribute/list.html
+++ b/themes/grass/layouts/contribute/list.html
@@ -16,7 +16,7 @@
 
 
 <!-- details page -->
-<section class="pt-4 bg-gray mt-5">
+<section class="pt-4 bg-gray mt-95">
   <div class="container">
   <div class="row">
         <div class="col-12 text-center">

--- a/themes/grass/layouts/download/addons.html
+++ b/themes/grass/layouts/download/addons.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 /header>

--- a/themes/grass/layouts/download/addons.html
+++ b/themes/grass/layouts/download/addons.html
@@ -1,18 +1,20 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
-</header>
+/header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/download/data.html
+++ b/themes/grass/layouts/download/data.html
@@ -1,17 +1,19 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/download/data.html
+++ b/themes/grass/layouts/download/data.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -1,12 +1,14 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
-</header>
+/header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
@@ -37,7 +39,7 @@
           <div class="row">
             <div class="col-lg-12">
 	      {{ range .Data.Pages }}
-	        {{ if not .Params.categories }}	      
+	        {{ if not .Params.categories }}
               <div class="section bg-white mb-4">
                 <div class="row nm">
                   <div class="col-4 text-center"><img src="{{.Site.BaseURL}}/images/logos/grass-{{.Title}}.jpg"></div>
@@ -71,7 +73,7 @@
                   </div>
                 </div>
               </div>
-              
+
             </div>
           </div>
         </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -10,12 +10,12 @@
       </div>
     </div>
   </div>
-/header>
+</header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
    <section>
-      <section class="pt-4 bg-gray">
+      <section class="pt-4 bg-gray mt-95">
         <div class="container">
           <div class="row">
             <div class="col-12 text-center">

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 /header>

--- a/themes/grass/layouts/download/os.html
+++ b/themes/grass/layouts/download/os.html
@@ -1,10 +1,12 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -12,7 +14,7 @@
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/download/os.html
+++ b/themes/grass/layouts/download/os.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/download/single.html
+++ b/themes/grass/layouts/download/single.html
@@ -1,17 +1,19 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single pt-5 bg-gray">
+<section class="single pt-5 bg-gray mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-4">
@@ -24,7 +26,7 @@
                 {{- end -}}
               </ul>
             </nav>
-    
+
             {{define "menu"}}
             {{- $currentNode := .currentnode -}}
             {{ with .sect }}

--- a/themes/grass/layouts/download/single.html
+++ b/themes/grass/layouts/download/single.html
@@ -4,8 +4,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/events/allevents.html
+++ b/themes/grass/layouts/events/allevents.html
@@ -3,8 +3,10 @@
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -12,13 +14,13 @@
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-8">
       <div id="news" class="p-5 bg-white">
 	      <h2 class="page-title">{{ .Title }}</h2>
-	     
+
 	      {{ $events := ( where .Data.Pages "Section" "events" ) }}
 	      {{ range (sort $events ".Params.event.start" "desc") }}
 <div class="row">

--- a/themes/grass/layouts/events/allevents.html
+++ b/themes/grass/layouts/events/allevents.html
@@ -4,8 +4,10 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/events/event.html
+++ b/themes/grass/layouts/events/event.html
@@ -4,8 +4,10 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/events/event.html
+++ b/themes/grass/layouts/events/event.html
@@ -3,8 +3,10 @@
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
@@ -13,7 +15,7 @@
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -1,11 +1,13 @@
   {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
-  
+
   <header class="hero-section overlay bg-cover banner" data-background="{{.Site.BaseURL}}/images/logos/banner.jpg">
-    <div class="container mb-20">
-    {{ partial "navigation.html" . }}
+    <div class="fixed-top">
+      {{ partial "banner.html" . }}
+       <div class="container mb-20 bg-white top-0 start-0 translate-middle">
+         {{ partial "navigation.html" . }}
+       </div>
     </div>
-    <div class="container">
+    <div class="container" style="margin-top: 100px;">
       <div class="row">
         <div class="col-lg-8 text-center mx-auto">
           <h1 class="mb-3"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="33%"></h1>{{ with .Site.Params.banner.description }}

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -3,9 +3,11 @@
   <header class="hero-section overlay bg-cover banner" data-background="{{.Site.BaseURL}}/images/logos/banner.jpg">
     <div class="fixed-top">
       {{ partial "banner.html" . }}
-       <div class="container mb-20 bg-white top-0 start-0 translate-middle">
-         {{ partial "navigation.html" . }}
-       </div>
+      <div class="bg-white">
+        <div class="container mb-20 bg-white">
+          {{ partial "navigation.html" . }}
+        </div>
+      </div>
     </div>
     <div class="container" style="margin-top: 100px;">
       <div class="row">

--- a/themes/grass/layouts/learn/books.html
+++ b/themes/grass/layouts/learn/books.html
@@ -1,19 +1,21 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
-      <div id="books" class="col-lg-12 p-5 bg-white">	
+      <div id="books" class="col-lg-12 p-5 bg-white">
 	<h2 class="page-title">{{ .Title }}</h2>
         {{ .Content }}
       </div>

--- a/themes/grass/layouts/learn/books.html
+++ b/themes/grass/layouts/learn/books.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/learn/gallery.html
+++ b/themes/grass/layouts/learn/gallery.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/learn/gallery.html
+++ b/themes/grass/layouts/learn/gallery.html
@@ -1,16 +1,18 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
-   
-  <section class="single section bg-gray pb-0">
+
+  <section class="single section bg-gray pb-0 mt-5">
     <div class="container">
       <div class="row">
         <div class="col-lg-4">
@@ -40,5 +42,5 @@
       </div>
     </div>
     </section>
-    
+
   {{ partial "footer.html" . }}

--- a/themes/grass/layouts/learn/list.html
+++ b/themes/grass/layouts/learn/list.html
@@ -1,16 +1,18 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-    
+
 <section class="pt-4 bg-gray">
   <div class="container">
   <div class="row">
@@ -43,7 +45,7 @@
             <b>GRASS</b> GIS<img src="/images/logos/grasslogo_wiki.png" width="34%" alt="GRASS GIS">
         </a>
     </div>
-       
+
     <div class="col-lg-8 col-sm-6 mb-4 bg-white">
         <img src="/images/gallery/temporal/tgrass_flowchart.png" width="40%" alt="TGRASS Flowchart" style="float:right;padding-top:20px">
         <a href="https://github.com/veroandreo/grass_opengeohub2019/raw/master/pdf/tgrass_lst.pdf" class="px-4 py-4 d-block htl"><h3 class="mt-2 mb-4">Time series in GRASS GIS</h3></a>
@@ -70,7 +72,7 @@
   </div>
 
 </div>
-      
+
 <div class="row justify-content-center">
 
      <div class="col-lg-8 col-sm-6 mb-4 bg-white">

--- a/themes/grass/layouts/learn/list.html
+++ b/themes/grass/layouts/learn/list.html
@@ -14,8 +14,7 @@
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-
-<section class="pt-4 bg-gray">
+<section class="pt-4 bg-gray mt-95">
   <div class="container">
   <div class="row">
         <div class="col-12 text-center">

--- a/themes/grass/layouts/learn/list.html
+++ b/themes/grass/layouts/learn/list.html
@@ -4,10 +4,12 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
-  </div>
+ </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 

--- a/themes/grass/layouts/learn/manuals.html
+++ b/themes/grass/layouts/learn/manuals.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/learn/manuals.html
+++ b/themes/grass/layouts/learn/manuals.html
@@ -1,18 +1,20 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
     <div class="col-lg-8">

--- a/themes/grass/layouts/learn/overview.html
+++ b/themes/grass/layouts/learn/overview.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom position-relative">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/learn/overview.html
+++ b/themes/grass/layouts/learn/overview.html
@@ -1,19 +1,21 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
 
 
 {{ "<!-- navigation -->" | safeHTML }}
 <header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
-      <div class="col-lg-12 p-5 bg-white">	
+      <div class="col-lg-12 p-5 bg-white">
 	<h2 class="page-title">{{ .Title }}</h2>
         {{ .Content }}
       </div>

--- a/themes/grass/layouts/news/allnews.html
+++ b/themes/grass/layouts/news/allnews.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom bg-white">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>

--- a/themes/grass/layouts/news/allnews.html
+++ b/themes/grass/layouts/news/allnews.html
@@ -1,17 +1,20 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
+
 
 {{ "<!-- navigation -->" | safeHTML }}
-<header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+<header class="shadow-bottom bg-white">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 
-<section class="pt-4 bg-gray">
+<section class="pt-4 bg-gray" style="margin-top: 95px;">
   <div class="container">
   <div class="row">
         <div class="col-12 text-center">
@@ -32,7 +35,7 @@
       {{ if ne $prev 3000}}
         </div></div></div>
 	{{ end }}
-	
+
  <div class="panel-group">
   <div class="panel panel-default">
     <div class="panel-heading">
@@ -52,7 +55,7 @@
       {{ $prev = .Date.Format "2006"}}
       {{end}}
       {{end}}
-     </ul>    
+     </ul>
    </div>
   </div>
   </div>
@@ -84,7 +87,7 @@
     </div>
     {{ end }}
     {{ end }}
-    </div>  
+    </div>
   </div>
   </div>
   </div>

--- a/themes/grass/layouts/news/news.html
+++ b/themes/grass/layouts/news/news.html
@@ -1,17 +1,20 @@
 {{ partial "head.html" . }}
-{{ partial "banner.html" . }}
+
 
 {{ "<!-- navigation -->" | safeHTML }}
-<header class="shadow-bottom position-relative">
-  <div class="container">
-    {{ partial "navigation.html" . }}
+<header class="shadow-bottom">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="container bg-white">
+      {{ partial "navigation.html" . }}
+    </div>
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
 
 
 <!-- details page -->
-<section class="single section bg-gray pb-0">
+<section class="single section bg-gray pb-0 mt-5">
   <div class="container">
     <div class="row">
       <div class="col-lg-12">

--- a/themes/grass/layouts/news/news.html
+++ b/themes/grass/layouts/news/news.html
@@ -5,8 +5,10 @@
 <header class="shadow-bottom">
   <div class="fixed-top">
     {{ partial "banner.html" . }}
-    <div class="container bg-white">
-      {{ partial "navigation.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
**Expected behavior of banner and nav bar element (due fixed position are still visible) during page scrolling**:

Example:

**A. home page URL**

1. Desktop layout

![banner_navbar_fixed_pos_desktop_layout_0](https://github.com/OSGeo/grass-website/assets/50632337/43ae2b55-ecb1-443a-9be3-9436f0bea12b)


2. Mobile layout 

![banner_navbar_fixed_pos_mobile_layout_0](https://github.com/OSGeo/grass-website/assets/50632337/6d870b61-3659-4500-b82e-099308afccf5)

**B. about/community/ URL**

1. Desktop layout

![banner_navbar_fixed_pos_desktop_layout_1](https://github.com/OSGeo/grass-website/assets/50632337/c6ec0485-1ad8-4d4f-8d33-d7f02cc6df0a)

2. Mobile layout 

![banner_navbar_fixed_pos_mobile_layout_1](https://github.com/OSGeo/grass-website/assets/50632337/8b55a97c-8662-4358-a6aa-994ec03cd94d)




