### PR TITLE
news: mastodon news feed support added

### DIFF
--- a/themes/grass/layouts/events/allevents.html
+++ b/themes/grass/layouts/events/allevents.html
@@ -39,9 +39,13 @@
       </div>
       </div>
       <div class="col-md-4 bg-white">
-        <h3 class="mt-20"><a href="#">@GRASSGIS</a></h3>
+        <h3 class="mt-20"><a href="#">@GRASSGIS on Mastodon</a></h3>
 
         {{ partial "mastodon.html" . }}
+
+        <h3 class="mt-20"><a href="#">@GRASSGIS on X</a></h3>
+
+        {{ partial "twitter.html" . }}
       </div>
     </div>
   </div>

--- a/themes/grass/layouts/events/allevents.html
+++ b/themes/grass/layouts/events/allevents.html
@@ -41,7 +41,7 @@
       <div class="col-md-4 bg-white">
         <h3 class="mt-20"><a href="#">@GRASSGIS</a></h3>
 
-        {{ partial "twitter.html" . }}
+        {{ partial "mastodon.html" . }}
       </div>
     </div>
   </div>

--- a/themes/grass/layouts/news/allnews.html
+++ b/themes/grass/layouts/news/allnews.html
@@ -67,7 +67,7 @@
     <div class="row">
     	<h3 class="mt-20 grasscolor">@GRASSGIS</h3>
     </div>
-    {{ partial "twitter.html" . }}
+    {{ partial "mastodon.html" . }}
     <div class="row">
     <h3 class="mt-20 grasscolor">Next events</h3>
     {{ $events := where ( where $.Site.Pages "Section" "events" ) ".Params.event.start" "!=" nil }}

--- a/themes/grass/layouts/news/allnews.html
+++ b/themes/grass/layouts/news/allnews.html
@@ -65,9 +65,13 @@
   </div>
   <div class="col-md-4 bg-white">
     <div class="row">
-    	<h3 class="mt-20 grasscolor">@GRASSGIS</h3>
+     <h3 class="mt-20 grasscolor">@GRASSGIS on Mastodon</h3>
     </div>
     {{ partial "mastodon.html" . }}
+    <div class="row">
+     <h3 class="mt-20 grasscolor">@GRASSGIS on X</h3>
+    </div>
+    {{ partial "twitter.html" . }}
     <div class="row">
     <h3 class="mt-20 grasscolor">Next events</h3>
     {{ $events := where ( where $.Site.Pages "Section" "events" ) ".Params.event.start" "!=" nil }}

--- a/themes/grass/layouts/partials/mastodon.html
+++ b/themes/grass/layouts/partials/mastodon.html
@@ -1,0 +1,7 @@
+<div>
+
+    <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox"
+     width="350" height="700"
+     src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Fgrassgis&theme=auto&size=100&header=false&replies=false&boosts=true"></iframe>
+
+</div>


### PR DESCRIPTION
This PR ~~replaces~~ adds on top of the broken X feed our mastodon news feed from https://fosstodon.org/@grassgis .

Code kindly crafted with https://www.mastofeed.com/

Screenshot:

![image](https://github.com/OSGeo/grass-website/assets/1295172/ab2f75fc-ab63-4522-b936-28e3264e5e10)


May replace X (formerly Twitter) since their feed is broken if not login'ed to X.
Fixes #380