### PR TITLE
download: GRASS GIS on Mac moved to new site

### DIFF
--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Mac"
-date: 2020-12-21T11:02:05+06:00
+date: 2023-08-231T11:02:05+06:00
 description: "Download bundled GRASS GIS binaries for your Mac"
 weight: 3
 layout: "os"
@@ -33,7 +33,7 @@ or install the latest available version from <a href="https://ports.macports.org
 <ul>
 <li>
  {{< donateDialog isToggle=true >}}  
-    <a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a>
+    <a href="https://cmbarton.github.io/grass-mac/_pages/download-grass/"><i class="fa fa-download"></i> Download </a>
  {{< /donateDialog  >}} 
  </li>
 </ul>
@@ -56,7 +56,7 @@ or install the latest available version from <a href="https://ports.macports.org
 <ul>
 <li>
  {{< donateDialog isToggle=true >}}  
- <a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a>
+ <a href="https://cmbarton.github.io/grass-mac/_pages/download-grass/"><i class="fa fa-download"></i> Download </a>
  {{< /donateDialog  >}} 
  </li>
 </ul>
@@ -79,7 +79,7 @@ or install the latest available version from <a href="https://ports.macports.org
 <ul>
 <li>
  {{< donateDialog isToggle=true >}}  
-<a href="http://grassmac.wikidot.com/downloads"><i class="fa fa-download"></i> Download </a>
+<a href="https://cmbarton.github.io/grass-mac/_pages/download-grass/"><i class="fa fa-download"></i> Download </a>
  {{< /donateDialog  >}} 
 </li>
 </ul>

--- a/content/news/2023_06_24_GRASS_GIS_8_3_released.md
+++ b/content/news/2023_06_24_GRASS_GIS_8_3_released.md
@@ -62,7 +62,7 @@ Thank you all contributors!!
 - Windows
   - [64bit standalone installer](https://grass.osgeo.org/grass83/binary/mswindows/native/WinGRASS-8.3.0-1-Setup.exe)
 - macOS
-  - [Official Application Bundle](http://grassmac.wikidot.com/downloads)
+  - [Official Application Bundle](https://cmbarton.github.io/grass-mac/_pages/download-grass/)
 - Linux
   - [Debian](https://tracker.debian.org/pkg/grass)
   - [Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)

--- a/content/news/2023_08_06_GRASS_GIS_7_8_8_released.md
+++ b/content/news/2023_08_06_GRASS_GIS_7_8_8_released.md
@@ -31,7 +31,7 @@ bugs fixed at
 - winGRASS 7.8.8/OSGeo4W:
 [64bit OSGeo4W installer](http://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe)
 - Mac
-    - forthcoming at [Official Application Bundle](http://grassmac.wikidot.com/downloads)
+    - forthcoming at [Official Application Bundle](https://cmbarton.github.io/grass-mac/_pages/download-grass/)
     - [MacPorts](https://ports.macports.org/port/grass7/)
 - Linux
     - [Debian](https://tracker.debian.org/pkg/grass)


### PR DESCRIPTION
Old:
- http://grassmac.wikidot.com/downloads

New:
- https://cmbarton.github.io/grass-mac/