### PR TITLE
news: GRASS GIS docker images moved to OSGeo org

### DIFF
--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -40,8 +40,7 @@ This restructuring is intended to improve clarity, streamline
 versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
-In summary, as we have phased out the repository under mundialis, we
-anticipate improved maintenance and a more streamlined user experience
-for GRASS GIS Docker images within the OSGeo framework.
+In summary, as we moved the repository from mundialis to the OSGeo
+organisation, we took the opportunity to clean up the Docker tags.
 
 _Carmen Tawalika (mundialis), Markus Neteler and The GRASS Dev Team_

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -19,7 +19,7 @@ for the GRASS GIS docker images.
    width="20%" style="float:right;padding-left:25px;padding-top:5px">
 </a>
 
-Historically, these docker images have been maintained and hosted under
+In the past years, these docker images have been maintained and hosted under
 the mundialis organisation's repository. The company mundialis
 (https://www.mundialis.de) has played a crucial role in providing and
 maintaining these images, ensuring their availability and stability for
@@ -27,7 +27,7 @@ the wider GIS community. The GRASS GIS development community extends
 its sincere appreciation to mundialis for their technical expertise and
 consistent support over the years.
 
-In a strategic move, the Docker images have now been moved to the OSGeo
+In a strategic move, the **GRASS GIS Docker images have now been moved** to the OSGeo
 organisation's repository on Docker Hub. They can be accessed under
 OSGeo GRASS GIS on Docker Hub:
 
@@ -41,7 +41,7 @@ versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
 In summary, as we have phased out the repository under mundialis, we
-anticipate robust development, improved maintenance and a more
+anticipate improved maintenance and a more
 streamlined user experience for GRASS GIS docker images within the
 OSGeo framework.
 

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -20,16 +20,16 @@ for the GRASS GIS docker images.
 </a>
 
 In the past years, these docker images have been maintained and hosted under
-the mundialis organisation's repository. The company mundialis
-(https://www.mundialis.de) has played a crucial role in providing and
-maintaining these images, ensuring their availability and stability for
+the mundialis organisation's repository. The company
+[mundialis](https://www.mundialis.de) has played a crucial role in providing
+and maintaining these images, ensuring their availability and stability for
 the wider GIS community. The GRASS GIS development community extends
 its sincere appreciation to mundialis for their technical expertise and
 consistent support over the years.
 
-In a strategic move, the **GRASS GIS Docker images have now been moved** to the OSGeo
-organisation's repository on Docker Hub. They can be accessed under
-OSGeo GRASS GIS on Docker Hub:
+In a strategic move, the **GRASS GIS Docker images have now been shifted**
+to the OSGeo organisation's repository on Docker Hub. They can be accessed
+under OSGeo GRASS GIS on Docker Hub:
 
 [https://hub.docker.com/r/osgeo/grass-gis/](https://hub.docker.com/r/osgeo/grass-gis/tags?page=1&ordering=-name)
 
@@ -41,19 +41,7 @@ versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
 In summary, as we have phased out the repository under mundialis, we
-anticipate improved maintenance and a more
-streamlined user experience for GRASS GIS docker images within the
-OSGeo framework.
+anticipate improved maintenance and a more streamlined user experience
+for GRASS GIS docker images within the OSGeo framework.
 
-**About GRASS GIS**
-
-The Geographic Resources Analysis Support System
-([https://grass.osgeo.org/](/)), commonly referred to as GRASS GIS, is
-an Open Source Geographic Information System providing powerful raster,
-vector and [geospatial processing capabilities](https://grass.osgeo.org/learn/overview/).
-It can be used either as a stand-alone application, as backend for other
-software packages such as QGIS and R, or in the cloud. It is
-distributed freely under the terms of the GNU General Public License (GPL).
-GRASS GIS is a founding member of the Open Source Geospatial Foundation (OSGeo).
-
-_The GRASS Dev Team_
+_Carmen Tawalika (mundialis), Markus Neteler and The GRASS Dev Team_

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -1,0 +1,59 @@
+---
+title: "New docker images for GRASS GIS"
+date: 2023-08-27T11:42:00+03:00
+layout: "news"
+author: GRASS Development Team
+---
+
+### Moving GRASS GIS Docker Images to the OSGeo Repository
+
+In the field of open source software development and deployment, the
+accessibility and maintenance of resources is of paramount importance.
+To this end, there has been a major change in the repository structure
+for the GRASS GIS docker images.
+
+<a href="https://hub.docker.com/r/osgeo/grass-gis/">
+  <img src="https://grass.osgeo.org/images/logos/grass-Docker.jpg"
+   alt="GRASS GIS docker images"
+   title="GRASS GIS docker images"
+   width="20%" style="float:right;padding-left:25px;padding-top:5px">
+</a>
+
+Historically, these docker images have been maintained and hosted under
+the mundialis organisation's repository. The company mundialis
+(https://www.mundialis.de) has played a crucial role in providing and
+maintaining these images, ensuring their availability and stability for
+the wider GIS community. The GRASS GIS development community extends
+its sincere appreciation to mundialis for their technical expertise and
+consistent support over the years.
+
+In a strategic move, the Docker images have now been moved to the OSGeo
+organisation's repository on Docker Hub. They can be accessed under
+OSGeo GRASS GIS on Docker Hub:
+
+[https://hub.docker.com/r/osgeo/grass-gis/](https://hub.docker.com/r/osgeo/grass-gis/tags?page=1&ordering=-name)
+
+This migration is not just a change of repository location. The move to
+the OSGeo repository has been accompanied by a systematic clean-up and
+reorganisation of the tags associated with the GRASS GIS docker images.
+This restructuring is intended to improve clarity, streamline
+versioning and optimise the user experience when selecting appropriate
+image tags for deployment.
+
+In summary, as we have phased out the repository under mundialis, we
+anticipate robust development, improved maintenance and a more
+streamlined user experience for GRASS GIS docker images within the
+OSGeo framework.
+
+**About GRASS GIS**
+
+The Geographic Resources Analysis Support System
+([https://grass.osgeo.org/](/)), commonly referred to as GRASS GIS, is
+an Open Source Geographic Information System providing powerful raster,
+vector and [geospatial processing capabilities](https://grass.osgeo.org/learn/overview/).
+It can be used either as a stand-alone application, as backend for other
+software packages such as QGIS and R, or in the cloud. It is
+distributed freely under the terms of the GNU General Public License (GPL).
+GRASS GIS is a founding member of the Open Source Geospatial Foundation (OSGeo).
+
+_The GRASS Dev Team_

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -40,7 +40,21 @@ This restructuring is intended to improve clarity, streamline
 versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
+Now there are four different types of tags, while `{{ os }}` can be replaced with "alpine", "debian" or "ubuntu" (and for more recent versions also with "ubuntu_wxgui"):
+- `latest` for latest release (at this time 8.3) and with ubuntu operating system
+- `current-{{ os }}` for current releasebranch (at this time 8.3), e.g `current-ubuntu`
+- `{{ branch }}-{{ os }}` for all configured branches, e.g. `releasebranch_8_3-alpine`,  `main-debian`
+- `{{ tag }}-{{ os }}` for all published releases. e.g. `8.3.0-alpine`
+
+While naming of branches and tags is still the same, it adds `current-{{ os }}` and abandons deprecated naming style `latest-{{ os }}` and `stable-{{ os }}`. Also content of `latest` tag was changed from `main` branch to latest release.
+
+If `mundialis/grass-py3-pdal:latest-{{ os }}` was used containing the latest development version, it should now be replaced with `osgeo/grass-gis:main-{{ os }}`. For `mundialis/grass-py3-pdal:stable-{{ os }}` (which was formerly build upon releasebranch_7_8) a switch to the current stable releasebranch `osgeo/grass-gis:current-{{ os }}` is recommended or the usage of a specific releasebranch `releasebranch_8_3-{{ os }}`. Old GRASS GIS Dockerimages with version 7.8 can still be found at mundialis/grass-py3-pdal.
+
 In summary, as we moved the repository from mundialis to the OSGeo
 organisation, we took the opportunity to clean up the Docker tags.
+
+Related docker build configuration changes can be found here:
+- [docker: Update dockerhub organization](https://github.com/OSGeo/grass/pull/3001)
+- [docker: CI update and simplification](https://github.com/OSGeo/grass/pull/3075)
 
 _Carmen Tawalika (mundialis), Markus Neteler and The GRASS Dev Team_

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -1,5 +1,5 @@
 ---
-title: "New docker images for GRASS GIS"
+title: "New Docker images for GRASS GIS"
 date: 2023-08-27T11:42:00+03:00
 layout: "news"
 author: GRASS Development Team
@@ -10,16 +10,16 @@ author: GRASS Development Team
 In the field of open source software development and deployment, the
 accessibility and maintenance of resources is of paramount importance.
 To this end, there has been a major change in the repository structure
-for the GRASS GIS docker images.
+for the GRASS GIS Docker images.
 
 <a href="https://hub.docker.com/r/osgeo/grass-gis/">
   <img src="https://grass.osgeo.org/images/logos/grass-Docker.jpg"
-   alt="GRASS GIS docker images"
-   title="GRASS GIS docker images"
+   alt="GRASS GIS Docker images"
+   title="GRASS GIS Docker images"
    width="20%" style="float:right;padding-left:25px;padding-top:5px">
 </a>
 
-In the past years, these docker images have been maintained and hosted under
+In the past years, these Docker images have been maintained and hosted under
 the mundialis organisation's repository. The company
 [mundialis](https://www.mundialis.de) has played a crucial role in providing
 and maintaining these images, ensuring their availability and stability for
@@ -35,13 +35,13 @@ under OSGeo GRASS GIS on Docker Hub:
 
 This migration is not just a change of repository location. The move to
 the OSGeo repository has been accompanied by a systematic clean-up and
-reorganisation of the tags associated with the GRASS GIS docker images.
+reorganisation of the tags associated with the GRASS GIS Docker images.
 This restructuring is intended to improve clarity, streamline
 versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
 In summary, as we have phased out the repository under mundialis, we
 anticipate improved maintenance and a more streamlined user experience
-for GRASS GIS docker images within the OSGeo framework.
+for GRASS GIS Docker images within the OSGeo framework.
 
 _Carmen Tawalika (mundialis), Markus Neteler and The GRASS Dev Team_

--- a/content/news/2023_08_27_GRASS_GIS_docker_organization.md
+++ b/content/news/2023_08_27_GRASS_GIS_docker_organization.md
@@ -40,20 +40,34 @@ This restructuring is intended to improve clarity, streamline
 versioning and optimise the user experience when selecting appropriate
 image tags for deployment.
 
-Now there are four different types of tags, while `{{ os }}` can be replaced with "alpine", "debian" or "ubuntu" (and for more recent versions also with "ubuntu_wxgui"):
+**Migrating to the new structure**
+
+Now there are four different types of tags, while `{{ os }}` can be replaced
+with "alpine", "debian" or "ubuntu" (and for more recent versions also with
+"ubuntu_wxgui"):
+
 - `latest` for latest release (at this time 8.3) and with ubuntu operating system
 - `current-{{ os }}` for current releasebranch (at this time 8.3), e.g `current-ubuntu`
 - `{{ branch }}-{{ os }}` for all configured branches, e.g. `releasebranch_8_3-alpine`,  `main-debian`
 - `{{ tag }}-{{ os }}` for all published releases. e.g. `8.3.0-alpine`
 
-While naming of branches and tags is still the same, it adds `current-{{ os }}` and abandons deprecated naming style `latest-{{ os }}` and `stable-{{ os }}`. Also content of `latest` tag was changed from `main` branch to latest release.
+While naming of branches and tags is still the same, it adds `current-{{ os }}`
+and abandons deprecated naming style `latest-{{ os }}` and `stable-{{ os }}`.
+Also content of `latest` tag was changed from `main` branch to latest release.
 
-If `mundialis/grass-py3-pdal:latest-{{ os }}` was used containing the latest development version, it should now be replaced with `osgeo/grass-gis:main-{{ os }}`. For `mundialis/grass-py3-pdal:stable-{{ os }}` (which was formerly build upon releasebranch_7_8) a switch to the current stable releasebranch `osgeo/grass-gis:current-{{ os }}` is recommended or the usage of a specific releasebranch `releasebranch_8_3-{{ os }}`. Old GRASS GIS Dockerimages with version 7.8 can still be found at mundialis/grass-py3-pdal.
+If `mundialis/grass-py3-pdal:latest-{{ os }}` was used containing the latest
+development version, it should now be replaced with `osgeo/grass-gis:main-{{ os }}`.
+For `mundialis/grass-py3-pdal:stable-{{ os }}` (which was formerly build upon
+`releasebranch_7_8`) a switch to the current stable releasebranch
+`osgeo/grass-gis:current-{{ os }}` is recommended or the usage of a specific
+releasebranch `releasebranch_8_3-{{ os }}`. Old GRASS GIS Docker images with
+version 7.8 can still be found at mundialis/grass-py3-pdal.
 
 In summary, as we moved the repository from mundialis to the OSGeo
 organisation, we took the opportunity to clean up the Docker tags.
 
 Related docker build configuration changes can be found here:
+
 - [docker: Update dockerhub organization](https://github.com/OSGeo/grass/pull/3001)
 - [docker: CI update and simplification](https://github.com/OSGeo/grass/pull/3075)
 


### PR DESCRIPTION
GRASS GIS docker images moved from mundialis to OSGeo dockerhub organization.

Co-Authored-By: @mmacata
