### PR TITLE
data: update 'legacy_version' to GRASS GIS 7.8.8

### DIFF
--- a/data/grass.json
+++ b/data/grass.json
@@ -3,7 +3,7 @@
     "current_version_short": "8.3",
     "current_version_underscore": "8_3",
     "current_version_nodots": "83",
-    "legacy_version": "7.8.7",
+    "legacy_version": "7.8.8",
     "legacy_version_short": "7.8",
     "legacy_version_underscore": "7_8",
     "legacy_version_nodots": "78",

--- a/data/grass.json
+++ b/data/grass.json
@@ -11,5 +11,4 @@
     "preview_version_short":"8.4",
     "preview_version_underscore": "8_4",
     "preview_version_nodots":"84"
- }
- 
+}


### PR DESCRIPTION
Required after release of
https://grass.osgeo.org/news/2023_08_06_grass_gis_7_8_8_released/