### PR TITLE
Citation: moved to separate page and add google scholar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -207,6 +207,12 @@ greyColorDark = "#A0A0A0"
 
       [[Languages.en.menu.main]]
         parent = "About"
+        name = "Citation"
+        URL = "/about/citation"
+        weight = 1
+
+      [[Languages.en.menu.main]]
+        parent = "About"
         name = "License"
         URL = "/about/license"
         weight = 1

--- a/content/about/citation.md
+++ b/content/about/citation.md
@@ -1,0 +1,46 @@
+---
+title: "Citation"
+date: 2023-11-09T05:05:05+05:00
+layout: "general"
+---
+
+### Citing GRASS GIS Software
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5176030.svg)](https://doi.org/10.5281/zenodo.5176030)
+
+Please cite GRASS GIS when using the software in your work. Here are some choices
+depending on the version used:
+
+- GRASS Development Team, 2023. Geographic Resources Analysis Support System (GRASS)
+Software, Version 8.3. Open Source Geospatial Foundation. https://grass.osgeo.org
+
+- GRASS Development Team, 2020. Geographic Resources Analysis Support System (GRASS)
+Software, Version 7.8. Open Source Geospatial Foundation. https://grass.osgeo.org
+
+- GRASS Development Team, 2022. Geographic Resources Analysis Support System (GRASS)
+Programmer's Manual. Open Source Geospatial Foundation. Electronic document: 
+https://grass.osgeo.org/programming8/
+
+<p> Use the following BibTeX entry for citing the <b>GRASS GIS</b> software in
+scientific work written in LaTeX.</p>
+
+<pre style="background-color:#CCCCCC">
+@Manual{GRASS_GIS_software,
+    title = {Geographic Resources Analysis Support System (GRASS GIS) Software, Version 8.3},
+    author = {{GRASS Development Team}},
+    organization = {Open Source Geospatial Foundation},
+    address = {USA},
+    year = {2023},
+    url = {https://grass.osgeo.org},
+    doi = {10.5281/zenodo.5176030}
+}
+</pre>
+
+For more options see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository).
+
+#### GRASS GIS Google Scholar profile
+Citing GRASS GIS in your work enables us to track the impact of this open source software on research.
+Have a look at our [Google Scholar](https://scholar.google.com/citations?user=gJ0ZB0cAAAAJ)
+profile for examples of GRASS GIS applications in the most diverse fields.
+Are you using GRASS GIS in your research and your publication is missing?
+[Let us know](https://forms.gle/cDEvMJu7d6nvxLKn9) and we will add it to the profile.

--- a/content/about/license.md
+++ b/content/about/license.md
@@ -30,37 +30,3 @@ Questions regarding details of this policy can be directed to
 this <a href="mailto:grass-web@lists.osgeo.org" target="_blank">email address</a>.
 
 See also the [Frequently Asked Questions about the GNU GPL](https://www.gnu.org/licenses/gpl-faq.html).
-
-### Citing GRASS GIS Software
-
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5176030.svg)](https://doi.org/10.5281/zenodo.5176030)
-
-Please cite GRASS when using the software in your work. Here are some choices
-depending on the version used:
-
-- GRASS Development Team, 2022. Geographic Resources Analysis Support System (GRASS)
-Software, Version 8.2. Open Source Geospatial Foundation. https://grass.osgeo.org
-
-- GRASS Development Team, 2020. Geographic Resources Analysis Support System (GRASS) 
-Software, Version 7.8. Open Source Geospatial Foundation. https://grass.osgeo.org
-
-- GRASS Development Team, 2022. Geographic Resources Analysis Support System (GRASS) 
-Programmer's Manual. Open Source Geospatial Foundation. Electronic document: 
-https://grass.osgeo.org/programming8/
-
-<p> Use the following BibTeX entry for citing the <b>GRASS GIS</b> software in 
-scientific work written in LaTeX.</p>
-
-<pre style="background-color:#CCCCCC">
-@Manual{GRASS_GIS_software,
-    title = {Geographic Resources Analysis Support System (GRASS GIS) Software, Version 8.2},
-    author = {{GRASS Development Team}},
-    organization = {Open Source Geospatial Foundation},
-    address = {USA},
-    year = {2022},
-    url = {https://grass.osgeo.org},
-    doi = {10.5281/zenodo.5176030}
-}
-</pre>
-
-For more options see also: [GRASS GIS Citation Repository](https://grasswiki.osgeo.org/wiki/GRASS_Citation_Repository).

--- a/content/contribute/_index.en.md
+++ b/content/contribute/_index.en.md
@@ -61,14 +61,16 @@ Feel free to announce your planned development to the [GRASS developers mailing 
 For **paid opportunities** to develop code for GRASS GIS, check out our [stipend program](https://grasswiki.osgeo.org/wiki/Student_Grants) for students
 and [Google Summer of Code](https://summerofcode.withgoogle.com) program for students and open source beginners with our [list of ideas](https://trac.osgeo.org/grass/wiki/GSoC).
 
-### Cite GRASS GIS 
-<i class="fa fa-book fa-7x" style="float:left;padding-right:15px"></i>
+### Cite GRASS GIS
+<i class="fa fa-book fa-9x" style="float:left;padding-right:15px"></i>
 
 If you use GRASS GIS for developing applications, products or for your scientific
-work, please [cite](/about/license/)
+work, please [cite](/about/citation/)
 it properly to raise awareness and visibility of the multiple uses of the
 software. 
 
 Have a look at our 
 [Google Scholar](https://scholar.google.com/citations?user=gJ0ZB0cAAAAJ)
-profile for examples of applications in the most diverse fields.
+profile for examples of GRASS GIS applications in the most diverse fields.
+Are you using GRASS GIS in your research and your publication is missing?
+[Let us know](https://forms.gle/cDEvMJu7d6nvxLKn9) and we will add it to the Google Scholar profile.


### PR DESCRIPTION
Citation moved from About-License to separate page About-Citation to be more prominent (and removed it from License page).
I added Google scholar profile to that page. I just updated the citation to 2023 and 8.3 version.

I included a google form for people to add their publications, it's linked to grass.devteam@gmail.com.

![image](https://github.com/OSGeo/grass-website/assets/7494312/136d391e-4e2c-41a9-bf40-d2af27700a79)
