### PR TITLE
Update Repology badge URL for MacPorts

### DIFF
--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -17,7 +17,7 @@ layout: "os"
  {{< /donateDialog  >}} 
 or install the latest available version from <a href="https://ports.macports.org/port/grass/" target="_blank">MacPorts</a> 
 <a href="https://repology.org/project/grass/versions" target="_blank"> 
-  <img class="inl" src="https://repology.org/badge/version-for-repo/macports/grass.svg" alt="MacPorts package">
+  <img class="inl" src="https://repology.org/badge/version-for-repo/macports/grass-gis.svg" alt="MacPorts package">
 </a>
 (see this brief <a href="https://grasswiki.osgeo.org/wiki/Compiling_on_macOS_using_MacPorts" target="_blank">introduction</a> on using MacPorts).
 </div>


### PR DESCRIPTION
Update URL to Repology badge for MacPorts version (https://grass.osgeo.org/download/mac/).

It is now broken:

<img width="344" alt="image" src="https://github.com/OSGeo/grass-website/assets/14186207/96641d06-b61a-4fc5-b485-c6ee6b5c5144">
