### PR TITLE
Update Windows installer binary version

### DIFF
--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -28,7 +28,7 @@ Standalone installer: install GRASS GIS with the required support packages.
 
  
 *  {{< donateDialog isToggle=true >}}  
-<a href="/grass{{< currentVersionNoDots.inline  >}}{{- .Site.Data.grass.current_version_nodots -}}{{</currentVersionNoDots.inline >}}/binary/mswindows/native/WinGRASS-{{< currentVersion.inline  />}}-2-Setup.exe" target="blank">
+<a href="/grass{{< currentVersionNoDots.inline  >}}{{- .Site.Data.grass.current_version_nodots -}}{{</currentVersionNoDots.inline >}}/binary/mswindows/native/WinGRASS-{{< currentVersion.inline  />}}-3-Setup.exe" target="blank">
 <i class="fa fa-download"></i> Download 64bit 
 </a>
 {{< /donateDialog  >}} 
@@ -44,7 +44,7 @@ Standalone installer: install GRASS GIS with the required support packages.
 </div>
 
 *  {{< donateDialog isToggle=true >}}  
-<a href="/grass{{< legacyVersionNoDots.inline  />}}/binary/mswindows/native/x86_64/WinGRASS-{{< legacyVersion.inline  />}}-2-Setup-x86_64.exe" target="blank">
+<a href="/grass{{< legacyVersionNoDots.inline  />}}/binary/mswindows/native/x86_64/WinGRASS-{{< legacyVersion.inline  />}}-3-Setup-x86_64.exe" target="blank">
 <i class="fa fa-download"></i> Download 64bit
 </a>
 {{< /donateDialog  >}} 


### PR DESCRIPTION
This PR updates Windows installers to:

* https://grass.osgeo.org/grass83/binary/mswindows/native/WinGRASS-8.3.1-3-Setup.exe
* https://grass.osgeo.org/grass78/binary/mswindows/native/x86_64/WinGRASS-7.8.8-3-Setup-x86_64.exe

Unfortunaly the installers introduced by #410 are broken, see https://github.com/OSGeo/grass/pull/3419 for details.