### PR TITLE
news: post about the community meeting in Prague, 2024 edition

### DIFF
--- a/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
+++ b/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
@@ -1,0 +1,48 @@
+---
+title: "GRASS GIS Community meeting in Prague! Again!!"
+date: 2024-03-18T14:12:42-05:00
+layout: "news"
+author: Veronica Andreo and the GRASS Development Team
+---
+
+#### Once more the GRASS GIS team is organizing the annual **Community Meeting**!! 
+
+<a href="/images/news/grass_community2023_prague_fotowall.jpg">
+  <img src="/images/news/grass_community2023_prague_fotowall.jpg"
+   alt="Prague 2023 Community Meeting"
+   title="Prague 2023 Community Meeting"
+   width="65%" style="float:right;padding-left:25px;padding-top:15px">
+</a>
+
+The [GRASS GIS Community Meeting](https://grasswiki.osgeo.org/wiki/GRASS_Community_Meeting_Prague_2024) 
+will take place from **June 13 to 19, 2023**, at the 
+[NC State European Center in Prague](https://prague.ncsu.edu/about/), Czech Republic.
+
+Community meetings are great opportunities to support the development of GRASS GIS by 
+actively contributing to the source code, documentation, translations, website or likewise. 
+The community meeting is also a get-together where supporters, contributors, power 
+users and developers make decisions and tackle larger problems related to the project, discuss 
+and resolve bugs, draw the project roadmap and work on new features. 
+We welcome people committed to improving the GRASS GIS interfaces to QGIS, GDAL, 
+PostGIS, R, OGC services and willing to celebrate with us the 
+**41st birthday of GRASS GIS!!**
+
+To support as many attendants as possible **we welcome sponsorship and financial support**
+ via [OpenCollective](https://opencollective.com/osgeo/projects/grass/contribute).
+Your contribution makes a difference!!
+
+
+<div align="center">
+<button class="btn btn-primary">
+<b><a href="https://opencollective.com/grass/contribute" target="_blank">Support GRASS GIS Community Meeting</a></b>
+</button>
+</div>
+
+<br>
+
+Keep an eye on the wiki page for updates and agenda details:
+<https://grasswiki.osgeo.org/wiki/GRASS_Community_Meeting_Prague_2024>. 
+You are all welcome to participate and support us by donating!!
+
+
+*Veronica Andreo and the GRASS Dev Team*

--- a/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
+++ b/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
@@ -47,8 +47,8 @@ via [OpenCollective](https://opencollective.com/osgeo/projects/grass/contribute)
 Your contribution makes a difference!!
 
 <div align="center">
-<button class="btn btn-primary">
-<b><a href="https://opencollective.com/grass/contribute" target="_blank">Support GRASS GIS Community Meeting</a></b>
+<button class="btn btn-grass">
+<a href="https://opencollective.com/grass/contribute" target="_blank">Support GRASS GIS Community Meeting</a>
 </button>
 </div>
 

--- a/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
+++ b/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
@@ -1,11 +1,11 @@
 ---
-title: "GRASS GIS Community meeting in Prague! Again!!"
+title: "2024 GRASS GIS Community meeting in Prague!"
 date: 2024-03-18T14:12:42-05:00
 layout: "news"
 author: Veronica Andreo and the GRASS Development Team
 ---
 
-#### Once more the GRASS GIS team is organizing the annual **Community Meeting**!! 
+#### GRASS GIS team announcing the annual **Community Meeting**!! 
 
 <a href="/images/news/grass_community2023_prague_fotowall.jpg">
   <img src="/images/news/grass_community2023_prague_fotowall.jpg"
@@ -15,7 +15,7 @@ author: Veronica Andreo and the GRASS Development Team
 </a>
 
 The [GRASS GIS Community Meeting](https://grasswiki.osgeo.org/wiki/GRASS_Community_Meeting_Prague_2024) 
-will take place from **June 13 to 19, 2023**, at the 
+will take place from **June 14 to 19, 2024**, at the 
 [NC State European Center in Prague](https://prague.ncsu.edu/about/), Czech Republic.
 
 Community meetings are great opportunities to support the development of GRASS GIS by 

--- a/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
+++ b/content/news/2024_03_18_GRASS_Community_meeting_Prague_2024.md
@@ -5,32 +5,46 @@ layout: "news"
 author: Veronica Andreo and the GRASS Development Team
 ---
 
-#### GRASS GIS team announcing the annual **Community Meeting**!! 
-
-<a href="/images/news/grass_community2023_prague_fotowall.jpg">
-  <img src="/images/news/grass_community2023_prague_fotowall.jpg"
-   alt="Prague 2023 Community Meeting"
-   title="Prague 2023 Community Meeting"
-   width="65%" style="float:right;padding-left:25px;padding-top:15px">
-</a>
+### The GRASS GIS team announces the annual **Community Meeting**!! 
 
 The [GRASS GIS Community Meeting](https://grasswiki.osgeo.org/wiki/GRASS_Community_Meeting_Prague_2024) 
 will take place from **June 14 to 19, 2024**, at the 
 [NC State European Center in Prague](https://prague.ncsu.edu/about/), Czech Republic.
 
-Community meetings are great opportunities to support the development of GRASS GIS by 
-actively contributing to the source code, documentation, translations, website or likewise. 
-The community meeting is also a get-together where supporters, contributors, power 
-users and developers make decisions and tackle larger problems related to the project, discuss 
-and resolve bugs, draw the project roadmap and work on new features. 
-We welcome people committed to improving the GRASS GIS interfaces to QGIS, GDAL, 
-PostGIS, R, OGC services and willing to celebrate with us the 
-**41st birthday of GRASS GIS!!**
+Community meetings are great opportunities to support the development of GRASS GIS!
 
-To support as many attendants as possible **we welcome sponsorship and financial support**
- via [OpenCollective](https://opencollective.com/osgeo/projects/grass/contribute).
+<a href="/images/news/grass_community2023_prague_fotowall.jpg">
+  <img src="/images/news/grass_community2023_prague_fotowall.jpg"
+   alt="Prague 2023 Community Meeting"
+   title="Prague 2023 Community Meeting"
+   width="55%" style="float:right;padding-left:25px;padding-top:15px">
+</a>
+
+#### Join us
+
+* Write code
+* Write documentation
+* Translation
+* Website design and content
+* Integrations with other software (QGIS, GDAL, R, etc.)
+
+#### Plan for the future
+
+The community meeting is a get-together where **supporters**, **contributors**, 
+**power users** and **developers** make decisions and tackle larger problems 
+related to the project, discuss and fix bugs, draw the project roadmap and 
+work on new features. 
+
+#### Let's celebrate!
+
+Join us in celebrating **the 41st anniversary of GRASS GIS** and the community's 
+ongoing dedication and achievements over the past year.
+
+#### Support us
+
+To support as many attendants as possible **we welcome sponsorship and financial support** 
+via [OpenCollective](https://opencollective.com/osgeo/projects/grass/contribute).
 Your contribution makes a difference!!
-
 
 <div align="center">
 <button class="btn btn-primary">
@@ -42,7 +56,7 @@ Your contribution makes a difference!!
 
 Keep an eye on the wiki page for updates and agenda details:
 <https://grasswiki.osgeo.org/wiki/GRASS_Community_Meeting_Prague_2024>. 
-You are all welcome to participate and support us by donating!!
+**You are all welcome to participate and support the GRASS GIS project!!**
 
 
 *Veronica Andreo and the GRASS Dev Team*

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -215,6 +215,34 @@ a.nws:hover {
   border-color: var(--grey-color);
 }
 
+.btn-grass {
+  font-size: 18px;
+  color: var(--white-color) !important;
+  background: var(--grass-color);
+  border-radius: 5px;
+}
+.btn-grass:active {
+  background: var(--grass-color-alt);
+}
+.btn-grass:hover, .btn-grass:focus {
+  background: var(--grass-color-alt);
+  color: var(--white-color) 
+}
+.btn-grass:not(:disabled):not(.disabled).active, .btn-grass:not(:disabled):not(.disabled):active, .show>.btn-grass.dropdown-toggle {
+  color: var(--white-color);
+  background-color: var(--grass-color-alt);
+  border-color: var(--grass-color-alt);
+}
+.btn-grass a {
+  color: var(--white-color);
+}
+.btn-grass a:focus {
+  color: var(--white-color);
+}
+.btn-grass a:hover {
+  color: var(--white-color) !important;
+}
+
 .badge {
     font-size: 1rem !important;
 }


### PR DESCRIPTION
News post for the 2024 edition of the community meeting. Content is mostly copied from 2023's news.

![image](https://github.com/OSGeo/grass-website/assets/20075188/b96735e8-c2d3-417a-ad9b-aed9d8013265)
