### PR TITLE
Fix link to standalone Windows installer

### DIFF
--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -28,7 +28,7 @@ Standalone installer: install GRASS GIS with the required support packages.
 
  
 *  {{< donateDialog isToggle=true >}}  
-<a href="/grass{{< currentVersionNoDots.inline  >}}{{- .Site.Data.grass.current_version_nodots -}}{{</currentVersionNoDots.inline >}}/binary/mswindows/native/WinGRASS-{{< currentVersion.inline  />}}-3-Setup.exe" target="blank">
+<a href="/grass{{< currentVersionNoDots.inline  >}}{{- .Site.Data.grass.current_version_nodots -}}{{</currentVersionNoDots.inline >}}/binary/mswindows/native/WinGRASS-{{< currentVersion.inline  />}}-1-Setup.exe" target="blank">
 <i class="fa fa-download"></i> Download 64bit 
 </a>
 {{< /donateDialog  >}} 


### PR DESCRIPTION
The [website ](https://grass.osgeo.org/download/windows/#standalone-installers)points to a [standalone installer](https://grass.osgeo.org/grass83/binary/mswindows/native/WinGRASS-8.3.2-3-Setup.exe) for Windows which doesn't exist.
I thought last week it might be a temporary glitch (i.e. the website being updated while a new version was being uploaded) but now it is clear it wasn't very temporary...
I guess there was just an oversight and the link wasn't updated when the release was made.  This should fix it.