### PR TITLE
nav: Restructuring of nav layout and pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,180 +61,146 @@ greyColorDark = "#A0A0A0"
     [[Languages.en.menu.main]]
       weight = 1
       name = "About Us"
-      url = "/about"
       hasChildren = true
 
       [[Languages.en.menu.main]]
         parent = "About Us"
-        name = "Team"
+        name = "What is GRASS GIS"
+        URL = "/about/overview"
         weight = 1
-        URL = "/about/team"
 
       [[Languages.en.menu.main]]
         parent = "About Us"
-        name = "License"
-        URL = "/about/license"
+        name = "Team"
+        URL = "/about/team"
         weight = 2
+        
+      [[Languages.en.menu.main]]
+        parent = "About Us"
+        name = "Our Sponsors"
+        URL = "/about/sponsors"
+        weight = 3
+
+      [[Languages.en.menu.main]]
+        parent = "About Us"
+        name = "Project Road Map"
+        URL = "/about/roadmap"
+        weight = 4
+
+      [[Languages.en.menu.main]]
+        parent = "About Us"
+        name = "Governance"
+        URL = "/about/governance"
+        weight = 5
 
       [[Languages.en.menu.main]]
         parent = "About Us"
         name = "History"
         URL = "/about/history"
-        weight = 3
+        weight = 6
 
       [[Languages.en.menu.main]]
         parent = "About Us"
-        name = "Brand"
-        URL = "/about/brand"
-        weight = 4
-
-      [[Languages.en.menu.main]]
-        parent = "About Us"
-        name = "Credits"
-        URL = "/about/credits"
-        weight = 5
-
+        name = "Blog"
+        URL = "/about/blog"
+        weight = 7
+      
       [[Languages.en.menu.main]]
         parent = "About Us"
         name = "Citation"
         URL = "/about/citation"
-        weight = 6
+        weight = 8
+
+      [[Languages.en.menu.main]]
+        parent = "About Us"
+        name = "License"
+        URL = "/about/license"
+        weight = 9
 
     [[Languages.en.menu.main]]
       weight = 2
-      name = "Download"
-      url = "/download"
-
-      [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "GRASS GIS source code"
-        URL = "https://github.com/OSGeo/grass/tags"
-        weight = 1
-
-	    [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "GRASS GIS for Linux"
-        URL = "/download/linux"
-        weight = 2
-
- 	    [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "GRASS GIS for Windows"
-        URL = "/download/windows"
-        weight = 3
-
- 	    [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "GRASS GIS for Mac"
-        URL = "/download/mac"
-        weight = 4
-
- 	    [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "Docker images"
-        URL = "/download/docker"
-        weight = 5
-
-      [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "Addons"
-        URL = "/download/addons"
-        weight = 6
-
- 	    [[Languages.en.menu.main]]
-        parent = "Download"
-        name = "Sample data"
-        URL = "/download/data"
-        weight = 7
-        
-    [[Languages.en.menu.main]]
-      weight = 3
-      name = "Learn"
-      url = "/learn"
-
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "General overview"
-        URL = "/learn/overview"
-        weight = 1
-
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "First time users"
-        URL = "/learn/newcomers"
-        weight = 2
-
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "Manuals"
-        URL = "/learn/manuals"
-        weight = 3 
-
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "Tutorials"
-        URL = "/learn/tutorials"
-        weight = 4 
-
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "Gallery"
-        URL = "/learn/gallery"
-        weight = 5
-	  
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "Books"
-        URL = "/learn/books"
-        weight = 6
- 
-      [[Languages.en.menu.main]]
-        parent = "Learn"
-        name = "Try online"
-        URL = "/learn/tryonline"
-        weight = 7
-
-    [[Languages.en.menu.main]]
-      weight = 4
-      name = "Support"
-      url = "/support"
+      name = "Getting Started"
       hasChildren = true
 
       [[Languages.en.menu.main]]
-        parent = "Support"
+        parent = "Getting Started"
+        name = "Download"
+        URL = "/learn/download"
+        weight = 1
+
+      [[Languages.en.menu.main]]
+        parent = "Getting Started"
+        name = "Installation"
+        URL = "/learn/installation"
+        weight = 2
+
+      [[Languages.en.menu.main]]
+        parent = "Getting Started"
+        name = "First time users"
+        URL = "/learn/newcomers"
+        weight = 3
+
+      [[Languages.en.menu.main]]
+        parent = "Getting Started"
+        name = "Tutorials"
+        URL = "/learn/tutorials"
+        weight = 4
+
+    [[Languages.en.menu.main]]
+      weight = 3
+      name = "Get Involved"
+      url = "/contribute"
+
+    [[Languages.en.menu.main]]
+      weight = 4
+      name = "Documentation"
+      url = "/documentation"
+
+    [[Languages.en.menu.main]]
+      weight = 5
+      name = "Get Support"
+      hasChildren = true
+
+      [[Languages.en.menu.main]]
+        parent = "Get Support"
         name = "Community"
         URL = "/support/community"
         weight = 1
 
       [[Languages.en.menu.main]]
-        parent = "Support"
-        name = "Commercial Support"
+        parent = "Get Support"
+        name = "Commercial"
         URL = "/support/commercial"
-        weight = 2    
-      
+        weight = 2
+
+      [[Languages.en.menu.main]]
+        parent = "Get Support"
+        name = "Mentorship Program"
+        URL = "/support/mentorship"
+        weight = 3
+
+      [[Languages.en.menu.main]]
+        parent = "Get Support"
+        name = "Books"
+        URL = "/support/books"
+        weight = 4
+
     [[Languages.en.menu.main]]
-      weight = 5
-      name = "Contribute"
-      url = "/contribute"
+      weight = 6
+      name = "Sponsor Us"
       hasChildren = true
 
       [[Languages.en.menu.main]]
-        parent = "Contribute"
-        name = "Development"
-        URL = "/contribute/development"
+        parent = "Sponsor Us"
+        name = "Donate"
+        URL = "/sponsor/donate"
         weight = 1
 
       [[Languages.en.menu.main]]
-        parent = "Contribute"
-        name = "Sponsoring"
-        URL = "/contribute/sponsoring"
+        parent = "Sponsor Us"
+        name = "Corporate Sponsors"
+        URL = "/sponsor/corporate"
         weight = 2
-	  
-      [[Languages.en.menu.main]]
-        parent = "Contribute"
-        name = "Sponsors"
-        URL = "https://grasswiki.osgeo.org/wiki/Sponsors"
-        weight = 4
 
     # banner
     [Languages.en.params.banner]

--- a/content/about/blog.md
+++ b/content/about/blog.md
@@ -1,0 +1,7 @@
+---
+title: "Blog"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Blog

--- a/content/about/governance.md
+++ b/content/about/governance.md
@@ -1,0 +1,7 @@
+---
+title: "Governance"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Governance

--- a/content/about/overview.md
+++ b/content/about/overview.md
@@ -2,6 +2,7 @@
 title: "What is GRASS GIS?"
 date: 2022-04-25T10:12:05+02:00
 layout: "overview"
+aliases: [/learn/overview]
 ---
 
 <div class="container">

--- a/content/about/roadmap.md
+++ b/content/about/roadmap.md
@@ -1,0 +1,7 @@
+---
+title: "Project Roadmap"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Project Roadmap

--- a/content/about/sponsors.md
+++ b/content/about/sponsors.md
@@ -1,0 +1,7 @@
+---
+title: "Our Sponsors"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Our Sponsors

--- a/content/documentation/_index.en.md
+++ b/content/documentation/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Documentation"
+date: 2024-03-13T05:05:05+05:00
+icon: "fa fa-documentation"
+description: "GRASS GIS documentation"
+type : "pages"
+weight: 1
+---

--- a/content/documentation/brand.md
+++ b/content/documentation/brand.md
@@ -1,0 +1,7 @@
+---
+title: "Brand"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Brand

--- a/content/documentation/c.md
+++ b/content/documentation/c.md
@@ -1,0 +1,7 @@
+---
+title: "C API"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## C API

--- a/content/documentation/jupyter.md
+++ b/content/documentation/jupyter.md
@@ -1,0 +1,7 @@
+---
+title: "Jupyter API"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Jupyter API

--- a/content/documentation/python.md
+++ b/content/documentation/python.md
@@ -1,0 +1,8 @@
+---
+title: "Python API"
+date: 2024-03-13T05:05:05+05:00
+icon: "python"
+layout: "general"
+---
+
+## Python API

--- a/content/learn/books.md
+++ b/content/learn/books.md
@@ -2,6 +2,7 @@
 title: "GRASS GIS books"
 date: 2020-04-29T11:02:05+06:00
 layout: "books"
+aliases: [/learn/books]
 ---
 
 | | |

--- a/content/learn/download.md
+++ b/content/learn/download.md
@@ -1,0 +1,7 @@
+---
+title: "Download"
+date: 2022-08-15T11:02:05+02:00
+description: "Download GRASS GIS"
+weight: 1
+layout: "os"
+---

--- a/content/learn/installation.md
+++ b/content/learn/installation.md
@@ -1,0 +1,7 @@
+---
+title: "Installation"
+date: 2024-03-13T05:05:05+05:00
+layout: "general"
+---
+
+## Installation

--- a/content/sponsor/corporate.md
+++ b/content/sponsor/corporate.md
@@ -2,6 +2,7 @@
 title: "Sponsoring"
 date: 2021-02-02T11:02:05+06:00
 layout: "general"
+aliases: [/contribute/sponsoring/]
 ---
 
 ## Sponsoring the GRASS GIS project

--- a/content/sponsor/donate.md
+++ b/content/sponsor/donate.md
@@ -1,0 +1,7 @@
+---
+title: "Donate to GRASS GIS"
+date: 2022-08-15T11:02:05+02:00
+description: "Every donation helps to support the development of GRASS GIS."
+weight: 1
+layout: "donate"
+---

--- a/content/support/mentorship.md
+++ b/content/support/mentorship.md
@@ -1,0 +1,8 @@
+---
+title: "Mentorship Program"
+date: 2023-06-04 T10:12:05+02:00
+icon: "fa fa-user"
+description: "Get mentored by GRASS GIS developers"
+layout: "support"
+---
+

--- a/themes/grass/layouts/about/overview.html
+++ b/themes/grass/layouts/about/overview.html
@@ -1,0 +1,29 @@
+{{ partial "head.html" . }}
+
+
+{{ "<!-- navigation -->" | safeHTML }}
+<header class="shadow-bottom position-relative">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
+  </div>
+</header>
+{{ "<!-- /navigation -->" | safeHTML }}
+
+
+<section class="single section bg-gray pb-0 mt-5">
+  <div class="container">
+      <div class="col-lg-12 p-5 bg-white">
+	<h2 class="page-title">{{ .Title }}</h2>
+        {{ .Content }}
+      </div>
+  </div>
+</section>
+<!-- /details page -->
+
+
+{{ partial "footer.html" . }}

--- a/themes/grass/layouts/sponsor/donate.html
+++ b/themes/grass/layouts/sponsor/donate.html
@@ -1,0 +1,39 @@
+{{ partial "head.html" . }}
+
+{{ "<!-- navigation -->" | safeHTML }}
+<header class="shadow-bottom position-relative">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
+  </div>
+</header>
+{{ "<!-- /navigation -->" | safeHTML }}
+
+
+
+<!-- details page -->
+<section class="pt-4 bg-gray mt-95">
+  <div class="container">
+  <div class="row">
+        <div class="col-12 text-center">
+          <h2 class="section-title">#GrowGRASS</h2>
+        </div>
+  </div>
+  </div>
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="p-5 bg-white">
+	      {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+{{ partial "footer.html" . }}

--- a/themes/grass/layouts/sponsor/general.html
+++ b/themes/grass/layouts/sponsor/general.html
@@ -1,0 +1,31 @@
+{{ partial "head.html" . }}
+
+{{ "<!-- navigation -->" | safeHTML }}
+<header class="shadow-bottom position-relative">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="bg-white">
+      <div class="container bg-white">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
+  </div>
+</header>
+{{ "<!-- /navigation -->" | safeHTML }}
+
+
+<!-- details page -->
+<section class="single section bg-gray pb-0 mt-5">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="p-5 bg-white">
+	      {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
I've restructured the navbar to address issue #414. 

Existing pages are redirected to the new url using hugo's [aliases](https://gohugo.io/methods/page/aliases/). 

For example:
```
---md
title: "What is GRASS GIS?"
date: 2022-04-25T10:12:05+02:00
layout: "overview"
aliases: [/learn/overview]
---
```

I've added placeholders for content that is missing, so we can use this branch as a starting point for the remaining work.