### PR TITLE
learn/manuals: quick link to temporal was missing icon

### DIFF
--- a/themes/grass/layouts/partials/quicklinks.html
+++ b/themes/grass/layouts/partials/quicklinks.html
@@ -14,7 +14,7 @@
 <h4 class="mt-20 tind"><i class="ms ms-database-o ms-fw"></i> Database <a href="/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/database.html" target="_blank">(db.*)</a></h4>
 </div>
 <div class="card mb-1-5">
-<h4 class="mt-20 tind"><i class="fa fa-clock-o fa-fw"></i> Temporal <a href="/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/temporal.html" target="_blank">(t.*)</a></h4>
+<h4 class="mt-20 tind"><i class="fa fa-clock fa-fw"></i> Temporal <a href="/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/temporal.html" target="_blank">(t.*)</a></h4>
 </div>
 <div class="card mb-1-5">
 <h4 class="mt-20 tind"><i class="ms ms-map-rolled-o ms-fw"></i> Display <a href="/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/display.html" target="_blank">(d.*)</a></h4>


### PR DESCRIPTION
Font awesome icon name fixed, now it displays a clock.

![Screenshot from 2024-04-17 16-27-38](https://github.com/OSGeo/grass-website/assets/20075188/bb4868c2-9b38-4be9-ac2a-175bf9ca6f58)
