### PR TITLE
History: Embed CERL video instead of picture

### DIFF
--- a/content/about/history.md
+++ b/content/about/history.md
@@ -25,7 +25,11 @@ started exploring the use of GIS for environmental research, monitoring and mana
 <p>Several universities adopted GRASS as an important training and research environment and many conducted short-courses for the public, in addition to using GRASS in their own curricula. Indeed, in 1988, GRASS received an award for quality software from the Urban and Regional Information Systems Association (URISA) in <b>1988</b>, only 4 years after the first release.</p>
 </div>
 <div class="col-lg-4 col-sm-12">
-<a href="https://av.tib.eu/media/12963" target="_blank"><img src="/images/gallery/marketing/grass_movie_CERL_1987.png"  width="93%" /></a>
+<div style="position: relative; width: 100%; aspect-ratio: 16 / 9;">
+  <iframe src="https://av.tib.eu/player/12963" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+</div>
+US Army CERL official GRASS GIS video narrated by William Shatner. <a href="https://doi.org/10.5446/12963" target="_blank">DOI.</a>
+<br><br>
 <h4 class="mt-4">Further reading</h4>
 <ul>
 <li><a href="https://tldp.org/HOWTO/GIS-GRASS/history.html"> A Brief History of GRASS <small> (D. Hastings) </small></a></li>

--- a/content/about/history.md
+++ b/content/about/history.md
@@ -28,7 +28,7 @@ started exploring the use of GIS for environmental research, monitoring and mana
 <div style="position: relative; width: 100%; aspect-ratio: 16 / 9;">
   <iframe src="https://av.tib.eu/player/12963" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
 </div>
-US Army CERL official GRASS GIS video narrated by William Shatner. <a href="https://doi.org/10.5446/12963" target="_blank">DOI.</a>
+Official GRASS GIS video of the US Army CERL, narrated by William Shatner (<a href="https://doi.org/10.5446/12963" target="_blank">DOI</a>)
 <br><br>
 <h4 class="mt-4">Further reading</h4>
 <ul>


### PR DESCRIPTION
![image](https://github.com/OSGeo/grass-website/assets/20075188/58aaa6b8-a042-4885-9a06-dd3e5cd4a27d)

Add CERL video with <iframe> instead of a picture. Now it's clear that it is a video and it can be played in place. Caption and DOI added as well. 

Addresses #433