### PR TITLE
releases.md: add creation of new G84 release branch

### DIFF
--- a/content/about/history/releases.md
+++ b/content/about/history/releases.md
@@ -21,7 +21,7 @@ layout: "timeline"
           <div class="panel-body">
 <ul class="list-unstyled releases">
 
-<li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 10 July 2024</span> Creation of the GRASS GIS 8.4 release branch (<a href="https://github.com/OSGeo/grass/tree/releasebranch_8_4">87847c2</a>)</li> <!-- 87847c25b85868298807c07743d17856d37fdf4a -->
+<li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 10 June 2024</span> Creation of the GRASS GIS 8.4 release branch (<a href="https://github.com/OSGeo/grass/tree/releasebranch_8_4">87847c2</a>)</li> <!-- 87847c25b85868298807c07743d17856d37fdf4a -->
 
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 07 Mar 2024</span> <b>GRASS GIS 8.3.2</b> &#160;<a href="https://github.com/OSGeo/grass/releases/tag/8.3.2">Changelog</a> - <a href="/grass83/source/">Source Code</a></li>
 

--- a/content/about/history/releases.md
+++ b/content/about/history/releases.md
@@ -1,6 +1,6 @@
 ---
 title: "History"
-date: 2024-03-07T14:12:05+02:00
+date: 2024-06-10T15:12:05+02:00
 layout: "timeline"
 ---
 
@@ -20,6 +20,8 @@ layout: "timeline"
         <div id="2023" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="heading1">
           <div class="panel-body">
 <ul class="list-unstyled releases">
+
+<li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 10 July 2024</span> Creation of the GRASS GIS 8.4 release branch (<a href="https://github.com/OSGeo/grass/tree/releasebranch_8_4">87847c2</a>)</li> <!-- 87847c25b85868298807c07743d17856d37fdf4a -->
 
 <li><span class="badge badge-pill bg-lgr grass-green"><i class="fa fa-calendar"></i> 07 Mar 2024</span> <b>GRASS GIS 8.3.2</b> &#160;<a href="https://github.com/OSGeo/grass/releases/tag/8.3.2">Changelog</a> - <a href="/grass83/source/">Source Code</a></li>
 


### PR DESCRIPTION
Add entry for creation of the GRASS GIS 8.4 release branch with commit hash.

(will show up in https://grass.osgeo.org/about/history/releases/)