### PR TITLE
Development: add URL to "Compile and install" under Quick links

### DIFF
--- a/themes/grass/layouts/contribute/devel.html
+++ b/themes/grass/layouts/contribute/devel.html
@@ -31,17 +31,18 @@
 
             </nav>
             <ul class="list-unstyled">
-	            <li><i class="ms ms-grass-gis"></i> &#160;<a href="https://github.com/OSGeo/grass/blob/master/CONTRIBUTING.md" target="_blank">How to contribute</a></li>
+                <li><i class="ms ms-grass-gis"></i> &#160;<a href="https://github.com/OSGeo/grass/blob/master/CONTRIBUTING.md" target="_blank">How to contribute</a></li>
                 <li><i class="fa fa-gears"></i> &#160;<a href="https://grasswiki.osgeo.org/wiki/GRASS_GIS_APIs" target="_blank">API's wiki page</a></li>
                 <li><i class="fa fa-file-text"></i> &#160;<a href="https://grass.osgeo.org/programming8/" target="_blank">Developer manual</a></li>
                 <li><i class="fa fa-code"></i> &#160;<a href="https://trac.osgeo.org/grass/wiki/Submitting" target="_blank">Submitting guidelines</a></li>
                 <li><i class="fa fa-code-fork"></i> &#160;<a href="https://trac.osgeo.org/grass/wiki/HowToGit" target="_blank">How to use git</a></li>
-	            <li><i class="fab fa-github"></i> &#160;<a href="https://github.com/OSGeo/grass/" target="_blank">Source code</a></li>
-	            <li><i class="fa fa-bug"></i> &#160;<a href="https://github.com/OSGeo/grass/issues" target="_blank">Bug Tracker</a></li>
+	        <li><i class="fab fa-github"></i> &#160;<a href="https://github.com/OSGeo/grass/" target="_blank">Source code</a></li>
+                <li><i class="fa fa-user-gear"></i> &#160;<a href="https://grasswiki.osgeo.org/wiki/Compile_and_Install" target="_blank">Compile GRASS GIS</a></li>
+	        <li><i class="fa fa-bug"></i> &#160;<a href="https://github.com/OSGeo/grass/issues" target="_blank">Bug Tracker</a></li>
                 <li><i class="fa fa-file-code"></i> &#160;<a href="https://github.com/wenzeslaus/foss4g-2022-developing-custom-grass-tools" target="_blank">Write your own tools</a></li>
                 <li><i class="fab fa-github"></i> &#160;<a href="https://github.com/OSGeo/grass/discussions" target="_blank">GitHub Discussions</a></li>
-	            <li><i class="fa fa-envelope"></i> &#160;<a href="https://lists.osgeo.org/listinfo/grass-dev" target="_blank">GRASS Developers Mailing list</a></li>
-                </ul>
+	        <li><i class="fa fa-envelope"></i> &#160;<a href="https://lists.osgeo.org/listinfo/grass-dev" target="_blank">GRASS Developers Mailing list</a></li>
+             </ul>
           </div>
 	 </div>
       </div>


### PR DESCRIPTION
So far there doesn't seem to be a hint on the website how to compile GRASS GIS.

Added URL to related ["Compile and install" Wiki page](https://grasswiki.osgeo.org/wiki/Compile_and_Install) now under Quick links (box) next to "Source code":

![image](https://github.com/user-attachments/assets/5d76abd8-1469-417a-b764-8fd66e85805a)
