### PR TITLE
Add Archlinux based distribution link in Readme 8.4.0

### DIFF
--- a/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
+++ b/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
@@ -61,6 +61,7 @@ Thanks to all contributors and financial supporters!
   - [Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)
   - [Fedora/Centos/EPEL](https://src.fedoraproject.org/rpms/grass)
   - [Gentoo](https://packages.gentoo.org/packages/sci-geosciences/grass)
+  - [AUR](https://aur.archlinux.org/packages/grass)
 
 Further binary packages for other platforms and distributions will follow shortly,
 please check at [software downloads](/download/software/).


### PR DESCRIPTION
Add Archlinux based distribution link.

Also available as an autobuild for arch4edu repository : https://github.com/arch4edu/arch4edu/
