### PR TITLE
Fix markdown syntax typos

### DIFF
--- a/content/news/2023_12_19_annual_report.md
+++ b/content/news/2023_12_19_annual_report.md
@@ -93,7 +93,7 @@ Check out the newly added [commercial support](/support/commercial) page featuri
 commercial support providers worldwide! The list now includes: [Margosa Environmental Solutions Ltd](https://margosa-env.com/),
 [mundialis GmbH & Co. KG](https://www.mundialis.de),
 [Center for Geospatial Analytics at NC State University](https://cnr.ncsu.edu/geospatial/engage),
- and [Kan Territory & IT](https://https//kan.com.ar/).
+ and [Kan Territory & IT](https://kan.com.ar/).
 
 ### GRASS GIS in Academia
 
@@ -122,7 +122,7 @@ NC State University to enhance teaching of an open-educational-resources course 
 </a>
 
 In April Veronica Andreo visited NC State University as a researcher and GRASS PSC Chair giving
-a [lecture]((https://cnr.ncsu.edu/geospatial/news/2023/04/26/spring-2023-geospatial-forum-rewind/)) and a [studio](https://veroandreo.github.io/grass_ncsu_2023/)
+a [lecture](https://cnr.ncsu.edu/geospatial/news/2023/04/26/spring-2023-geospatial-forum-rewind/) and a [studio](https://veroandreo.github.io/grass_ncsu_2023/)
 on leveraging remote sensing in public health, and highlighting use of GRASS GIS in her research. 
 The visit also resulted in a news article [How Open Science Can Both Advance and Hinder Equity in Research](https://cnr.ncsu.edu/geospatial/news/2023/12/01/open-science-equity/) which featured GRASS GIS and part of Vero’s story of involvement with the project.
 


### PR DESCRIPTION
Building pages locally is failing with hugo v0.128.2:

```
Error: error building site: render: failed to render pages: render of "page" failed: "/home/martin/src/grass-website/themes/grass/layouts/news/news.html:26:10": execute of template failed: template: news/news.html:26:10: executing "news/news.html" at <.Content>: error calling Content: "/home/martin/src/grass-website/content/news/2023_12_19_annual_report.md:1:1": execute of template failed: template: _default/_markup/render-link.html:1:14: executing "_default/_markup/render-link.html" at <urls.Parse>: error calling Parse: parse "(https://cnr.ncsu.edu/geospatial/news/2023/04/26/spring-2023-geospatial-forum-rewind/)": first path segment in URL cannot contain colon
```

This PR fixes two syntax errors. Now it builts successfully:

```
                   |  EN   
-------------------+-------
  Pages            |  220  
  Paginator pages  |    0  
  Non-page files   |    6  
  Static files     | 1136  
  Processed images |   57  
  Aliases          |    0  
  Cleaned          |    0  

Total in 660 ms
```