### PR TITLE
GRASS 8.4.0 news: update Ubuntu link + add Nix

### DIFF
--- a/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
+++ b/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
@@ -58,7 +58,7 @@ Thanks to all contributors and financial supporters!
   - [Official Application Bundle](https://cmbarton.github.io/grass-mac/download/)
 - Linux
   - [Debian](https://tracker.debian.org/pkg/grass)
-  - [Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)
+  - [Ubuntu](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable/+packages?field.name_filter=grass)
   - [Fedora/Centos/EPEL](https://src.fedoraproject.org/rpms/grass)
   - [Gentoo](https://packages.gentoo.org/packages/sci-geosciences/grass)
   - [AUR](https://aur.archlinux.org/packages/grass)

--- a/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
+++ b/content/news/2024_07_27_GRASS_GIS_8_4_0_released.md
@@ -62,6 +62,7 @@ Thanks to all contributors and financial supporters!
   - [Fedora/Centos/EPEL](https://src.fedoraproject.org/rpms/grass)
   - [Gentoo](https://packages.gentoo.org/packages/sci-geosciences/grass)
   - [AUR](https://aur.archlinux.org/packages/grass)
+  - [Nix](https://search.nixos.org/packages?channel=unstable&show=grass&size=1&type=packages&query=grass+gis)
 
 Further binary packages for other platforms and distributions will follow shortly,
 please check at [software downloads](/download/software/).


### PR DESCRIPTION
This PR:

- modify UbuntuGIS link to show grass packages only
- add Nix link