### PR TITLE
Overview: replace imgs that were archived

### DIFF
--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -41,14 +41,14 @@ and the full list of
 <a href="/about/history/releases" target="_blank">releases</a>
 for more details.</p>
 
-<p>The strength and success of GRASS GIS relies on the user community. 
+<!-- <p>The strength and success of GRASS GIS relies on the user community. 
 The <i>philosophy</i> of the GRASS GIS Development Team is to encourage users 
 to develop their own unique tools and applications as well as to improve 
-the existent ones.</p>
+the existing ones.</p> -->
 
 </div>
 <div class="col-lg-6 text-center">
-<img class="bsh" src="/images/gallery/gui/grass70_gui_example.png" width="89%" alt="GRASS GIS">
+<img class="bsh" src="/images/news/grass83_news_screenshot.png" width="99%" alt="GRASS GIS">
 </div>
 
 </div>
@@ -60,7 +60,7 @@ the existent ones.</p>
 <div class="row mt-20">
 
 <div class="col-lg-6 text-center">
-<img class="bsh" src="/images/gallery/gui/gui-grass-example-2.png" width="89%" alt="GRASS GIS">
+<img class="bsh" src="/images/gallery/vector/hexagons_3d_white_outlier.png" width="95%" alt="GRASS GIS">
 </div>
 
 <div class="col-lg-6">
@@ -109,7 +109,7 @@ Some selected relevant features are:
 <div class="row mt-20">
 
 <div class="col-lg-6 text-center">
-<img class="bsh" src="/images/other/grass_through_qgis.png" width="90%" alt="GRASS GIS through QGIS">
+<img class="bsh" src="/images/news/jupyter_interactive_viewshed.png" width="90%" alt="GRASS GIS through QGIS">
 </div>
 
 <div class="col-lg-6">

--- a/content/learn/tutorials.md
+++ b/content/learn/tutorials.md
@@ -70,13 +70,15 @@ layout: "overview"
 * [Αναπαραγωγή του χάρτη CORINE με το GRASS-GIS](https://sourceforge.net/projects/gregis.berlios/files/corine_grass-gis_el.pdf/download)
 
 ### Portuguese
-<img src="/images/gallery/temporal/grass760_temporal_plot_labels.png" width="40%" style="float:right">
 
 * [Curso - Introdução ao SIG com Software Livre (GRASS)](http://carlosgrohmann.com/downloads/sigcomsl_dados/aula_intro_grass_2021.pdf) (2021)
 * [Playlist de aulas sobre GRASS-GIS](https://www.youtube.com/playlist?list=PL9GztlLGb7RovKMMO2ohYdfxfILXjxwEy)
 * [Geoprocessamento com GRASS-GIS (2016)](https://figshare.com/articles/Geoprocessamento_com_GRASS-GIS/3502184)
 * [Geoprocessamento com Software Livre: GRASS-GIS e QGIS (2012)](https://figshare.com/articles/Geoprocessamento_com_Software_Livre_GRASS_GIS_e_QGIS/1004167)
+<img src="/images/gallery/temporal/grass760_temporal_plot_labels.png" width="33%" style="float:right">
 * [Introdução à Análise Digital de Terreno com GRASS-GIS (2008)](https://figshare.com/articles/Introdu_o_An_lise_Digital_de_Terreno_com_GRASS_GIS/1004165)
+
+
 
 ### Spanish
 


### PR DESCRIPTION
When we archived old GUI imgs, some links got broken. Here, I replaced those of the learn/overview page. I'll check other pages and fix as well. Wording of the text is material for a different PR and discussion ;-)

![image](https://github.com/user-attachments/assets/d0b54dd8-6a64-446a-a531-db7b70f8a450)
 