### PR TITLE
Shorten intro text on the main page

### DIFF
--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -27,14 +27,10 @@
       <div class="row justify-content-center">
         <div class="col-12 text-center">{{with .Site.Params.topics.title}}
             <p class="pd-20 bigr"><b>GRASS GIS</b>
-                offers powerful raster, vector, and geospatial processing
-                engines in a single integrated software suite. It includes tools for
-                terrain and ecosystem modeling, hydrology, visualization of raster and
-                vector data, management and analysis of geospatial data, and the
-                processing of satellite and aerial imagery. It comes with a temporal
-                framework for advanced time series processing and a Python API for
-                rapid geospatial programming. GRASS GIS has been optimized for
-                performance and large geospatial data analysis.</p>{{ end }}</div>
+                is a powerful computational engine for raster, vector, and geospatial processing.
+                It supports terrain and ecosystem modeling, hydrology, data management, and imagery processing.
+                With a built-in temporal framework and Python API, it enables advanced time series analysis
+                and rapid geospatial programming, optimized for large-scale analysis on various hardware configurations.</p>{{ end }}</div>
 	{{ range (where .Site.Pages "Type" "pages") }}{{ if not (in  .Section "about") }}
           <div class="col-lg-3 col-sm-6 mb-4">
           <a class="px-4 py-5 bg-white shadow text-center d-block fdiv" href="{{ .Permalink }}"><i class="{{ .Params.Icon }} icon d-block mb-40"></i>


### PR DESCRIPTION
This keeps the same idea of fully defining the software right on the main page, but makes it a bit shorter and more aligned with (one) engine (as opposed to containing a series of engines).

| Before | After |
| --- | --- |
|![Screenshot from 2024-08-29 15-42-34](https://github.com/user-attachments/assets/58d9a21a-87a2-4218-9a6c-d4012426925c) | ![Screenshot from 2024-08-29 15-41-59](https://github.com/user-attachments/assets/e8eef4c3-97f5-4f72-aea4-14c72938890c) |
