### PR TITLE
Take less vertical space in the banner

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -562,7 +562,7 @@ pre {
   z-index: 1;
 }
 .hero-section {
-  padding-bottom: 50px;
+  padding-bottom: 0px;
 }
 .navbar {
   padding: 0;
@@ -1389,9 +1389,9 @@ code{
   .section-title {
     margin-bottom: 32px;
     font-size: 22px !important;
-}
+  }
   .hero-section {
-    padding-bottom: 10px;
+    padding-bottom: 0px;
   }
 
   .mb-40 {

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -9,11 +9,11 @@
         </div>
       </div>
     </div>
-    <section class="mt-95">
+    <section class="pt-3 mt-95">
         <div class="container">
         <div class="row">
             <div class="col-lg-8 text-center mx-auto">
-            <h1 class="mb-3"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="33%"></h1>{{ with .Site.Params.banner.description }}
+            <h1 class="mb-3"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="25%"></h1>{{ with .Site.Params.banner.description }}
             <p class=" text-bold mb-4">{{ . }}</p>{{ end }}
             </div>
         </div>

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -9,7 +9,7 @@
         </div>
       </div>
     </div>
-    <section class="pt-5 mt-95">
+    <section class="mt-95">
         <div class="container">
         <div class="row">
             <div class="col-lg-8 text-center mx-auto">


### PR DESCRIPTION
The banner now takes less space by cutting space at the top and bottom.

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-29 16-13-21](https://github.com/user-attachments/assets/79c2c561-65a4-4791-b7e4-a4196036d177) | ![Screenshot from 2024-08-29 16-13-04](https://github.com/user-attachments/assets/350129ea-a7a3-4e46-a15f-02ee25b8a297) |
