### PR TITLE
footer: fix copyright display

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -255,30 +255,30 @@ greyColorDark = "#A0A0A0"
       title = "Geographic Resources Analysis Support System"
 
     # footer social icon
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = " fab fa-github"
       link = "https://github.com/OSGeo/grass"
 
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
           icon = " fa fa-comments"
           link = "https://gitter.im/grassgis/community"
 
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = " fab fa-mastodon"
       link = "https://fosstodon.org/@grassgis"
 
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = " fab fa-x-twitter"
       link = "https://twitter.com/grassgis"    
 
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = "fab fa-facebook"
       link = "https://www.facebook.com/groups/GRASS"
 
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = "fab fa-youtube"
       link = "https://www.youtube.com/results?search_query=grass+gis"
       
-    [[Languages.en.socialIcon]]
+    [[Languages.en.params.socialIcon]]
       icon = "fa fa-rss"
       link = "https://grass.osgeo.org/index.xml" 

--- a/config.toml
+++ b/config.toml
@@ -275,9 +275,9 @@ greyColorDark = "#A0A0A0"
       icon = "fab fa-facebook"
       link = "https://www.facebook.com/groups/GRASS"
 
-    [[Languages.en.params.socialIcon]]
-      icon = "fab fa-youtube"
-      link = "https://www.youtube.com/results?search_query=grass+gis"
+    #[[Languages.en.params.socialIcon]]
+    #  icon = "fab fa-youtube"
+    #  link = "https://www.youtube.com/results?search_query=grass+gis"
       
     [[Languages.en.params.socialIcon]]
       icon = "fa fa-rss"

--- a/config.toml
+++ b/config.toml
@@ -47,7 +47,7 @@ greyColorDark = "#A0A0A0"
 [Languages]
 
   # English Language
-  [Languages.en]
+  [Languages.en.params]
   languageName = "En"
   weight = 1
   languageCode = "en-us"

--- a/content/support/community.md
+++ b/content/support/community.md
@@ -69,7 +69,7 @@ Join the discussion also on the following channels:
 | <i class="fab fa-x-twitter"></i> |  [https://twitter.com/grassgis](https://twitter.com/grassgis) | @GRASSGIS |
 | <i class="fab fa-linkedin"></i> | [https://www.linkedin.com/company/grass-gis](https://www.linkedin.com/company/grass-gis) |  |
 | <i class="fab fa-facebook"></i> |  [https://www.facebook.com/groups/GRASS](https://www.facebook.com/groups/GRASS) | @GRASSGIS |
-| <i class="fab fa-youtube"></i> |  [https://www.youtube.com/...grass+gis](https://www.youtube.com/results?search_query=grass+gis) |  |
+<!-- | <i class="fab fa-youtube"></i> |  [https://www.youtube.com/...grass+gis](https://www.youtube.com/results?search_query=grass+gis) |  | -->
 
 ### GRASS Wiki
 GRASS GIS uses [wiki](https://grasswiki.osgeo.org/wiki/GRASS-Wiki) to organize community activities and provides space to share educational materials and technical solutions. To edit the wiki, please sign up [here](https://grasswiki.osgeo.org/wiki/Special:RequestAccount).


### PR DESCRIPTION
I addressed some warnings in compilation and that fixed the display of copyright info. Fixes #465. 

![image](https://github.com/user-attachments/assets/d6095b36-be1f-41f4-8e35-a457935b4178)
