### PR TITLE
Replace 'founding member' by 'project of OSGeo'

### DIFF
--- a/content/contribute/sponsoring.md
+++ b/content/contribute/sponsoring.md
@@ -11,7 +11,7 @@ layout: "general"
 ### Why sponsor?
 
 *The GRASS GIS project is a volunteer-based organization*, 
-it is an affiliated project and a project of the
+it is a project of the
 Open Source Geospatial Foundation ([OSGeo](https://osgeo.org/)).
 
 There is no cost to participate in the project itself or to use

--- a/content/contribute/sponsoring.md
+++ b/content/contribute/sponsoring.md
@@ -11,7 +11,7 @@ layout: "general"
 ### Why sponsor?
 
 *The GRASS GIS project is a volunteer-based organization*, 
-it is an affiliated project and founding member of the
+it is an affiliated project and a project of the
 Open Source Geospatial Foundation ([OSGeo](https://osgeo.org/)).
 
 There is no cost to participate in the project itself or to use

--- a/content/learn/overview.md
+++ b/content/learn/overview.md
@@ -16,7 +16,7 @@ Information System (GIS) technology built for vector and raster geospatial
 data management, geoprocessing, spatial modelling and visualization.</p>
 <p><b>GRASS GIS</b> is Free and Open Source Software released under the 
 terms of the <a href="/about/license">GNU General Public License (GPL >= v2)</a>. 
-GRASS GIS is also a founding member and an affiliated  project of the
+GRASS GIS is a project of the
 <a href="https://osgeo.org">Open Source Geospatial Foundation (OSGeo)</a>.</p>
 </div>
 </div>

--- a/themes/grass/layouts/partials/osgeo.html
+++ b/themes/grass/layouts/partials/osgeo.html
@@ -1,4 +1,4 @@
 <a href="https://www.osgeo.org/projects/grass-gis/" target="_blank" class="px-4 py-5 bg-gray text-center shadow d-block fdiv">
    <img src="{{ .Site.BaseURL }}/images/logos/osgeo-project.svg" width="75%" />
-   <p class="mt-3 mb-0"><b>GRASS GIS</b> is a founding member of the Open Source Geospatial Foundation</p>
+   <p class="mt-3 mb-0"><b>GRASS GIS</b> is a project of the Open Source Geospatial Foundation</p>
 </a>


### PR DESCRIPTION
Use project of OSGeo rather than founding member becuase the terminology is OSGeo project and that's also what needs to be highlighted.

The founding member has historical significance so it is kept in the history page, but removed from anywhere else.
