### PR TITLE
Use inverted white logo for index page

### DIFF
--- a/static/images/logos/grass_gis.svg
+++ b/static/images/logos/grass_gis.svg
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1.3823377in"
+   height="1.867206in"
+   viewBox="0 0 124.4104 168.04854"
+   id="svg4364"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="grass_gis.svg"
+   inkscape:export-filename="grass_gis_example.png"
+   inkscape:export-xdpi="640"
+   inkscape:export-ydpi="640">
+  <defs
+     id="defs4366" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="-39.519581"
+     inkscape:cy="102.74804"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer5"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="in"
+     showguides="false"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid915"
+       originx="-172.43438"
+       originy="-530.34202" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4369">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="white"
+     style="display:inline"
+     transform="translate(-9.7947447,-11.287251)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.81789947;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.52868856"
+       d="m 68.917814,133.69998 -4.335403,-4.35628 -2.535137,-4.96727 C 58.5928,117.60785 53.496583,108.4136 50.662805,103.83735 46.594749,97.267864 43.433757,92.851939 42.799267,92.851939 c -0.132933,0 0.324284,1.05119 1.016042,2.335978 2.275298,4.225869 10.367595,23.011113 10.049669,23.329043 -0.04037,0.0404 -9.47238,-9.3261 -20.960022,-20.814367 L 12.018332,76.814833 44.406617,44.427282 76.794901,12.039734 l 32.387739,32.388474 32.38774,32.388476 -21.74309,21.717823 -21.743084,21.717823 0.16362,-1.51523 c 0.343545,-3.18146 0.992773,-6.449 2.451684,-12.33926 1.73026,-6.985834 2.73743,-12.875587 2.73743,-16.00806 0,-1.192237 -0.0592,-2.108483 -0.13161,-2.036098 -0.0724,0.07238 -0.29245,1.046409 -0.48903,2.164499 -0.44954,2.556896 -2.22432,8.639077 -3.213387,11.012299 -0.413001,0.99099 -1.413181,3.74741 -2.222621,6.12539 -1.263481,3.71187 -1.621843,5.21257 -2.532827,10.60661 l -1.061119,6.28299 -1.114641,1.13643 -1.11464,1.13642 0.134245,-0.75762 c 0.07383,-0.41668 0.592888,-4.2237 1.153452,-8.46002 0.79394,-5.99999 1.62729,-10.66072 3.770402,-21.086938 1.513156,-7.361487 3.343926,-16.45286 4.068376,-20.203051 l 1.31718,-6.81853 3.34259,-6.565991 c 4.0563,-7.967977 4.53675,-9.282158 4.52393,-12.374369 -0.0109,-2.632531 -0.48936,-3.939191 -2.01615,-5.506177 -0.97592,-1.00162 -1.60973,-1.103814 -0.69337,-0.111801 0.69994,0.75773 1.33157,2.339162 1.32316,3.31284 -0.009,1.082475 -1.61886,5.051879 -3.37892,8.333163 -0.80287,1.496791 -1.49131,2.684725 -1.52987,2.639854 -0.0386,-0.04487 0.0805,-1.161183 0.26456,-2.480695 0.69162,-4.958212 1.34211,-10.562869 1.50215,-12.942579 0.14405,-2.142056 0.11388,-2.462247 -0.23198,-2.462247 -0.50444,0 -0.37922,-0.658864 -2.18392,11.490485 l -1.53802,10.354064 -3.920493,7.392872 c -5.807203,10.950642 -14.716829,29.18286 -16.409938,33.58048 -0.8153,2.11763 -1.570659,3.82124 -1.678576,3.7858 -0.107917,-0.0354 -0.524701,-0.6396 -0.926186,-1.34258 l -0.729972,-1.27813 4.102333,-7.810969 c 2.256285,-4.296032 5.442248,-10.026991 7.079917,-12.735462 1.637672,-2.708472 4.15747,-7.281536 5.599554,-10.162365 2.376462,-4.747429 2.621967,-5.36814 2.621967,-6.629126 0,-1.068312 -0.08793,-1.391255 -0.378808,-1.391255 -0.208344,0 -0.378807,0.177807 -0.378807,0.395126 0,1.490806 -5.110293,9.933779 -13.89986,22.964651 -1.217944,1.805648 -2.734612,4.192133 -3.370372,5.303301 -0.670635,1.172121 -1.157844,1.806716 -1.160491,1.511552 -0.0025,-0.279812 0.453495,-5.052783 1.01334,-10.606602 1.127928,-11.189358 1.496164,-17.358125 1.502945,-25.177653 0.0042,-4.802687 0.04983,-5.340098 0.55796,-6.565991 0.576593,-1.391064 1.000774,-4.524645 0.970578,-7.170013 -0.0099,-0.867844 0.197252,-2.232002 0.473961,-3.121063 0.372675,-1.197409 0.428052,-1.718752 0.228973,-2.155681 -0.170475,-0.374153 -0.177572,-0.728214 -0.02023,-1.009364 0.183722,-0.328292 0.09245,-0.582964 -0.377294,-1.052705 -0.610847,-0.610847 -0.673982,-1.312115 -0.21387,-2.375596 0.118612,-0.274158 -0.02263,-0.485528 -0.456604,-0.683254 -0.420557,-0.191618 -0.718347,-0.62053 -0.900503,-1.29701 -0.149687,-0.555894 -0.36786,-1.069864 -0.48483,-1.142155 -0.116971,-0.07229 -0.290901,-1.131443 -0.386515,-2.353671 l -0.173842,-2.222232 -1.12185,-0.994999 c -1.01187,-0.897451 -1.122641,-1.107206 -1.129884,-2.139543 -0.0097,-1.383323 -0.415094,-1.976785 -1.567711,-2.295038 -0.544912,-0.150457 -0.97809,-0.478844 -1.160898,-0.88006 -0.468273,-1.027751 -1.204013,-0.425025 -1.557051,1.275556 -0.159069,0.76623 -0.389755,1.331011 -0.512632,1.255067 -0.266666,-0.164808 -0.15174,2.815834 0.136512,3.54054 0.110493,0.277792 0.367869,0.699717 0.571945,0.937612 0.239073,0.27869 0.297922,0.593072 0.165451,0.883883 -0.113084,0.248242 -0.223082,0.56499 -0.244445,0.703886 -0.02136,0.138896 -0.126031,0.453453 -0.232595,0.699016 -0.232643,0.536091 0.229623,1.748364 0.896993,2.352325 0.580171,0.525048 0.611913,0.945876 0.103192,1.368077 -0.578052,0.47974 -0.453917,1.221968 0.315673,1.887452 l 0.69448,0.600536 -0.452079,0.84756 c -0.439209,0.823429 -0.437207,0.881184 0.07032,2.028541 0.287323,0.649541 0.63281,1.249218 0.767752,1.332616 0.134941,0.0834 0.245348,0.415117 0.245348,0.737151 0,0.322037 0.170463,0.726992 0.378807,0.899902 0.208344,0.17291 0.378807,0.502465 0.378807,0.732345 0,0.229881 0.192217,0.692392 0.427151,1.027808 0.234934,0.335414 0.403069,0.967446 0.373633,1.404516 -0.03246,0.482068 0.147202,1.049844 0.456733,1.443349 0.524489,0.666781 0.620562,1.458999 0.281908,2.324634 -0.309246,0.790464 0.361943,3.490943 0.967605,3.893087 0.504907,0.335247 0.523428,0.558135 0.523428,6.29891 0,4.87787 -0.183512,8.026813 -1.017373,17.457464 -1.065425,12.049546 -2.127199,21.531384 -2.482086,22.165534 -0.152462,0.27244 -0.72043,-0.50613 -2.095513,-2.872515 L 71.96448,95.498581 71.15636,89.818979 C 70.711893,86.695195 70.008332,81.26333 69.592887,77.748166 68.748316,70.602049 66.938686,58.536481 66.674326,58.288885 c -0.258735,-0.242328 0.12109,13.036809 0.533537,18.653151 0.198902,2.708472 0.597162,6.66982 0.88502,8.802995 0.287861,2.133177 0.476169,3.925715 0.418464,3.983423 -0.05771,0.0577 -1.73417,-2.483117 -3.725476,-5.646271 -3.88167,-6.165963 -18.731304,-28.486092 -19.78763,-29.74231 -0.502584,-0.597689 -0.63898,-0.662314 -0.646145,-0.306152 -0.01831,0.910337 2.430642,6.807173 6.33473,15.253392 2.891226,6.254966 5.941149,11.590177 13.471049,23.564826 l 6.113839,9.722721 0.417549,4.04061 c 0.229653,2.22233 0.935179,7.54898 1.567838,11.837 0.632658,4.28802 1.108352,7.83833 1.057097,7.88959 -0.05126,0.0512 -0.578583,-1.46839 -1.171833,-3.37698 C 70.632033,118.10588 65.03348,104.41972 61.786953,97.650163 58.767746,91.354605 53.74898,82.927256 50.28175,78.330996 c -1.781902,-2.362138 -7.36683,-8.039673 -8.678716,-8.822622 -0.811968,-0.484593 0.347447,0.961724 3.174195,3.959652 2.630546,2.789847 3.287519,3.681445 5.652829,7.671649 3.794827,6.401751 4.488335,7.736725 6.674788,12.848685 5.425786,12.68557 16.975936,44.06791 16.219026,44.06791 -0.03886,0 -2.021585,-1.96033 -4.406058,-4.35629 z"
+       id="path928"
+       inkscape:connector-curvature="0"
+       transform="scale(0.93750001)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.81789947;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.52868856"
+       d="m 76.972658,134.20506 c -0.448532,-3.36823 -0.814236,-6.65725 -0.812675,-7.30894 0.0029,-1.22623 1.358745,-6.06296 2.375208,-8.47335 l 0.580126,-1.37568 1.898963,3.24411 c 3.485753,5.95494 4.725904,8.38254 5.102697,9.98857 l 0.372869,1.58931 -4.213709,4.23001 c -2.31754,2.32651 -4.275417,4.23002 -4.350837,4.23002 -0.07542,0 -0.50411,-2.75582 -0.952642,-6.12405 z"
+       id="path930"
+       inkscape:connector-curvature="0"
+       transform="scale(0.93750001)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.81789947;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.52868856"
+       d="m 87.019323,122.63039 c -0.0015,-0.19677 -1.254866,-2.68742 -2.785369,-5.53479 l -2.782732,-5.17703 0.742411,-1.76777 c 1.127181,-2.68395 14.025944,-29.729223 14.774731,-30.978681 0.387656,-0.646859 0.656396,-0.910837 0.657809,-0.646153 0.0013,0.24613 -0.970206,4.332843 -2.158933,9.081585 -2.530782,10.110004 -3.448632,14.253419 -5.021751,22.669519 -1.16112,6.21193 -3.411624,14.32631 -3.426166,12.35332 z"
+       id="path932"
+       inkscape:connector-curvature="0"
+       transform="scale(0.93750001)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.67491567;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.52868856"
+       d="m 74.626168,117.09636 c 0,-0.008 -0.231026,-2.09164 -0.513392,-4.63072 -0.282366,-2.53909 -0.513393,-4.64503 -0.513393,-4.67987 0,-0.0348 0.362867,0.54255 0.806372,1.28308 l 0.806373,1.34643 -0.159145,3.00063 c -0.19699,3.71418 -0.181127,3.53366 -0.318438,3.62363 -0.05961,0.0391 -0.108377,0.0646 -0.108377,0.0568 z"
+       id="path934"
+       inkscape:connector-curvature="0"
+       transform="scale(0.93750001)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.67491567;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.52868856"
+       d="m 76.097809,115.9143 c -0.0039,-0.19414 0.286158,-3.42957 0.309815,-3.45569 0.01462,-0.0161 0.228342,0.30716 0.474939,0.71843 l 0.448358,0.74778 -0.366048,0.86639 c -0.348717,0.82537 -0.376286,0.87429 -0.582287,1.03317 -0.244434,0.18852 -0.282548,0.20056 -0.284777,0.0899 z"
+       id="path936"
+       inkscape:connector-curvature="0"
+       transform="scale(0.93750001)" />
+    <g
+       style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.31834248;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="g4549"
+       transform="matrix(1.7714456,0,0,1.7714456,-590.18703,-813.39454)"
+       inkscape:export-filename="grass_gis_logo_128x128.png"
+       inkscape:export-xdpi="111.73267"
+       inkscape:export-ydpi="111.73267">
+      <g
+         transform="matrix(0.78531774,0,0,0.78531774,56.306031,438.46065)"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.99999809px;line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="flowRoot5356">
+        <path
+           d="m 366.71975,139.218 c -3.74,0 -6.93,2.772 -6.93,7.92 0,5.21399 2.376,7.942 6.6,7.942 2.068,0 3.872,-0.572 5.346,-1.496 v -7.436 h -5.456 l 0.308,2.156 h 2.288 v 3.96 c -0.726,0.418 -1.562,0.594 -2.42,0.594 -2.376,0 -3.608,-1.56201 -3.608,-5.72 0,-4.092 1.848,-5.72 4.004,-5.72 1.298,0 2.156,0.396 3.168,1.232 l 1.584,-1.65 c -1.276,-1.1 -2.728,-1.782 -4.884,-1.782"
+           style="font-weight:500;line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Medium';letter-spacing:-1.77950382px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4046"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 377.64903,148.656 3.366,6.094 h 3.344 l -3.982,-6.622 c 2.06799,-0.814 3.08,-2.046 3.08,-4.114 0,-3.014 -2.04601,-4.466 -6.028,-4.466 h -4.532 v 15.202 h 2.904 v -6.094 h 1.848 m -1.848,-2.09 v -4.906 h 1.562 c 2.11199,0 3.058,0.704 3.058,2.354 0,1.826 -1.01201,2.552 -2.816,2.552 h -1.804"
+           style="letter-spacing:0px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4048"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 393.45224,151.23 0.946,3.52 h 3.08 l -4.708,-15.202 h -3.586 l -4.73,15.202 h 3.014 l 0.946,-3.52 h 5.038 m -0.594,-2.2 h -3.872 l 1.936,-7.26 1.936,7.26"
+           style="letter-spacing:0px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4050"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 403.5719,139.218 c -2.992,0 -5.17,1.672 -5.17,4.202 0,2.31 1.386,3.586 4.576,4.576 2.376,0.726 3.014,1.298 3.014,2.574 0,1.474 -1.166,2.266 -2.794,2.266 -1.584,0 -2.816,-0.572 -3.872,-1.562 l -1.54,1.716 c 1.254,1.232 3.058,2.09 5.478,2.09 3.63,0 5.764,-1.936 5.764,-4.664 0,-2.86 -1.848,-3.96 -4.51,-4.796 -2.53,-0.792 -3.124,-1.276 -3.124,-2.376 0,-1.188 0.99,-1.804 2.354,-1.804 1.254,0 2.31,0.396 3.366,1.32 l 1.474,-1.672 c -1.32,-1.21 -2.794,-1.87 -5.016,-1.87"
+           style="letter-spacing:0px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4052"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 415.68909,139.218 c -2.992,0 -5.17,1.672 -5.17,4.202 0,2.31 1.386,3.586 4.576,4.576 2.37599,0.726 3.014,1.298 3.014,2.574 0,1.474 -1.16601,2.266 -2.794,2.266 -1.584,0 -2.816,-0.572 -3.872,-1.562 l -1.54,1.716 c 1.254,1.232 3.058,2.09 5.478,2.09 3.62999,0 5.764,-1.936 5.764,-4.664 0,-2.86 -1.84801,-3.96 -4.51,-4.796 -2.53,-0.792 -3.124,-1.276 -3.124,-2.376 0,-1.188 0.99,-1.804 2.354,-1.804 1.254,0 2.31,0.396 3.366,1.32 l 1.474,-1.672 c -1.32,-1.21 -2.79401,-1.87 -5.016,-1.87"
+           style="letter-spacing:0px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4054"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(0.78531774,0,0,0.78531774,106.84321,438.46065)"
+         style="font-style:normal;font-variant:normal;font-weight:100;font-stretch:normal;font-size:21.99999809px;line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Thin';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="flowRoot6517">
+        <path
+           d="m 366.41175,139.57 c -2.816,0 -5.764,2.376 -5.764,7.612 0,5.10399 2.354,7.788 5.962,7.788 1.496,0 2.772,-0.506 3.74,-1.078 v -6.732 h -3.498 l 0.022,0.176 h 3.278 v 6.468 c -0.858,0.506 -2.024,0.99 -3.564,0.99 -3.498,0 -5.742,-2.61801 -5.742,-7.634 0,-5.126 2.86,-7.414 5.566,-7.414 1.342,0 2.376,0.396 3.432,1.188 l 0.088,-0.132 c -1.078,-0.814 -2.112,-1.232 -3.52,-1.232"
+           style="line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Thin';letter-spacing:-1.77950382px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4057"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 373.29062,154.75 v -14.96 h -0.198 v 14.96 h 0.198"
+           style="line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Thin';letter-spacing:-1.77950382px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4059"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 380.1279,139.57 c -2.376,0 -3.938,1.474 -3.938,3.388 0,2.002 0.99,2.816 4.026,3.762 2.79399,0.902 4.07,1.76 4.07,4.114 0,2.354 -1.71601,3.96 -4.268,3.96 -2.002,0 -3.168,-0.682 -4.246,-1.694 l -0.11,0.132 c 1.122,1.034 2.332,1.738 4.356,1.738 2.66199,0 4.444,-1.694 4.444,-4.158 0,-2.42 -1.32001,-3.344 -4.18,-4.246 -2.97,-0.924 -3.916,-1.694 -3.916,-3.608 0,-1.826 1.496,-3.212 3.762,-3.212 1.71599,0 2.772,0.528 3.74,1.408 l 0.11,-0.132 c -0.968,-0.858 -2.02401,-1.452 -3.85,-1.452"
+           style="line-height:125%;font-family:'Fira Sans';-inkscape-font-specification:'Fira Sans Thin';letter-spacing:-1.77950382px;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.40536773;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path4061"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       transform="matrix(0.66388457,0,0,0.66388457,-166.77887,-277.07945)"
+       id="g5376"
+       inkscape:export-filename="grass_gis_logo_128x128.png"
+       inkscape:export-xdpi="111.73267"
+       inkscape:export-ydpi="111.73267">
+      <path
+         id="path5382"
+         d="m 285.12239,550.68594 -3,3 22.53125,22.53125 -2.96875,2.96875 22.5,22.5 -3,3 38.46875,38.46875 38.5,-38.46875 -3,-3 22.5,-22.5 -2.96875,-2.96875 22.53125,-22.53125 -3,-3 -74.5625,74.53125 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="translate(256.15732,425.49844)"
+         id="g5386"
+         style="display:inline;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 30.875,210.40625 v 1.25 h 60.3125 v -1.25 z"
+           id="path5388"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path5390"
+           d="m 115.83638,210.40625 v 1.25 h 60.3125 v -1.25 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      </g>
+      <g
+         id="g5392"
+         inkscape:label="grayscale_opaque"
+         style="display:none;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 367.81011,602.52854 4.21781,4.2809 1.43857,-1.54392 -2.57138,-19.15924 0.21875,-3.09375 1.3125,-4.625 1.375,-4.25 1.5,-3.34375 4.875,8.1875 4.75,8.65625 1.05469,5.08007 6.62885,-6.5039 3.34766,-25.16992 7.03125,-34.0625 4.53125,-23.12499 9.1875,-18.21875 1.375,-3.78125 0.5,-2.21875 0.1875,-3.59375 -0.5625,-2.875 -1.3125,-2.59375 -2.40625,-2.40625 0.125,0.65625 1.1875,1.21875 1.09375,2.5625 0.125,2.0625 -1.5,4.125 -1.9375,4.4375 -4.15625,7.46875 2.3125,-17.25 0.65625,-9.0625 -0.84375,-0.15625 -4.65625,31 -0.875,1.5625 -7.65625,14.40625 -9.78125,19.37499 -8.21875,16.8125 -4.5625,11.71875 -2.59375,-4.4375 1.625,-3.34375 8.9375,-17.15625 9.0625,-15.125 3.78125,-7.37499 3.125,-6.125 0.84375,-2.09375 0.1875,-2.03125 -0.375,-1.5625 h -0.375 l -0.28125,1.375 -1.5625,3.59375 -3.78125,6.375 -10.8125,16.62499 -6.15625,9.125 -4.21875,7.46875 2.59375,-25.71875 0.96875,-10.96874 0.40625,-23.1875 h -0.0625 l 0.18755,-0.78125 0.59375,-1.4375 0.46875,-1.3125 0.5625,-0.96875 v -1.90625 l -0.1875,-2.40625 0.84375,-1.5625 -0.375,-2.28125 v -1.71875 l 0.3125,-0.96875 0.65625,-2.15625 0.46875,-1.15625 -0.875,-1.4375 0.75,-1.4375 -1.1875,-0.84375 -0.71875,-2.15625 1.03125,-1.6875 -1.4375,-0.46875 -0.625,-1.125 v -0.96875 l -0.65625,-1.09375 -0.65625,-0.59375 0.0625,-0.90625 v -1 l -0.3125,-2.71875 -0.21875,-1.5625 -0.96875,-0.71875 -0.46875,-0.84375 -1.09375,-0.53125 -0.65625,-1.1875 0.125,-1.34375 -0.125,-1.375 -0.71875,-1.1875 -1.25,-0.25 -1.15625,-0.40625 -0.59375,-0.84375 -0.40625,-0.90625 -0.90625,0.59375 -0.375,1.15625 -0.1875,1.25 -0.59375,1.96875 -0.40625,-0.65625 0.1875,2.40625 -0.125,0.53125 v 0.90625 l 0.34375,0.71875 0.3125,0.96875 0.59375,0.78125 0.25,0.34375 0.1875,0.90625 -0.75,0.5625 0.3125,0.8125 -0.71875,0.90625 0.125,0.71875 0.1875,0.71875 0.59375,0.71875 0.53125,0.65625 0.71875,0.625 0.125,0.53125 -0.25,0.78125 -0.59375,0.53125 -0.28125,0.4375 0.0937,1.125 0.90625,0.59375 0.53125,0.5625 0.3125,1.125 -0.96875,1.15625 -0.15625,0.8125 0.40625,0.90625 0.59375,0.71875 v 0.71875 l 0.4375,0.5625 0.40625,0.46875 0.3125,0.53125 -0.1875,0.90625 0.59375,0.84375 0.53125,0.125 0.1875,0.40625 -0.1875,0.71875 0.5,1.03125 0.53125,0.40625 0.40625,0.84375 -0.40625,1.4375 0.59375,1.3125 0.5625,0.25 0.28125,0.59375 0.125,1.6875 -0.3125,0.71875 -0.28125,0.84375 0.84375,4.25 1.5,0.96875 -0.125,18.4375 -1.75,19.90624 -1.03125,11.53125 -1.6875,14 -0.65625,1.6875 -5.5625,-9.53125 -1.90625,-12.78125 -2.46875,-20.74999 -2.9375,-19.25 0.21875,17.5625 1.0313,14.53124 1.78125,13.84375 -12.40625,-19.65625 -17.8125,-26.71874 -4.09375,-5.6875 h -0.34375 l 1.1875,3.40625 2.21875,5.53125 3.25,7.375 5.6875,12.1875 3.4375,6.12499 4.25,7.375 8.78125,13.90625 7.9375,12.625 1.21875,11.3125 3.78125,25.84375 -0.002,-0.0161 -4.37265,-13.57769 -9.25,-22.78125 -7.375,-15.3125 -9.78125,-15.90625 -4.96875,-6.53124 -3.96875,-3.96875 -6.46875,-6 2.6875,3.3125 4.34375,4.4375 2.5625,2.87499 1.6875,2.9375 2.03125,3.25 3.3125,5.6875 2.875,5.28125 2.9375,6.53125 3.59375,8.71875 7.03125,18.1875 7.375,19.1875 4.4375,13.5625 z m -12.9406,-12.88394 -1.2869,-3.44454 -2.375,-4.5 -5.1875,-9.90625 -7.3125,-13.1875 -5.15625,-8.46875 -4.78125,-7.3125 -2.59375,-3.59375 -2.15625,-2.15625 3.71875,7.0625 3.40625,7.90625 5.125,11.65625 2.25,5.15625 2.25393,6.7029 z m -30.8494,-52.56954 -0.0625,-0.125 -0.1875,-0.125 z m 78.46875,-23.53124 -1.25,5.21874 -5.65625,22.625 -2.75,12.84375 -2.875,15.53125 -3.1875,10.125 -1.125,-2.625 -7.25,-13.4375 2.4375,-5.65625 7.9375,-16.625 4.25,-8.9375 5.6875,-12 z m 7.03125,16.84374 -1.03125,6 -2.9375,9.96875 -2.9375,7.375 -3.25,9.59375 -1.71875,9.4375 -1.625,10.0332 5.875,-5.9707 0.25,-3.0625 0.65625,-5.3125 1.5625,-7.5 3.40625,-13.40625 1.5625,-9.9375 z m -42.0625,27.34375 2.375,3.96875 -0.5,9.25 -0.375,0.28125 z m 4,6.65625 1.375,2.28125 -1.0625,2.5 -0.78125,0.5625 z"
+           id="path5394" />
+        <path
+           id="path5396"
+           d="m 297.50037,539.11859 -3,3 22.53125,22.53125 -2.96875,2.96875 22.5,22.5 -3,3 38.46875,38.46875 38.5,-38.46875 -3,-3 22.5,-22.5 -2.96875,-2.96875 22.53125,-22.53125 -3,-3 -74.5625,74.53125 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path5398"
+           d="m 372.03162,420.77484 -93.375,93.40625 93.375,93.40625 93.40625,-93.40625 z m 0,1.65625 91.75,91.75 -91.75,91.75 -91.75,-91.75 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <g
+           transform="translate(268.5353,413.93109)"
+           id="g5400"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             d="m 30.875,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             id="path5402"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5404"
+             d="m 115.83638,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        </g>
+      </g>
+      <g
+         style="display:none;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:label="grayscale_transparent"
+         id="g5406">
+        <path
+           id="path5408"
+           d="m 367.81011,602.52854 4.21781,4.2809 1.43857,-1.54392 -2.57138,-19.15924 0.21875,-3.09375 1.3125,-4.625 1.375,-4.25 1.5,-3.34375 4.875,8.1875 4.75,8.65625 1.05469,5.08007 6.62885,-6.5039 3.34766,-25.16992 7.03125,-34.0625 4.53125,-23.12499 9.1875,-18.21875 1.375,-3.78125 0.5,-2.21875 0.1875,-3.59375 -0.5625,-2.875 -1.3125,-2.59375 -2.40625,-2.40625 0.125,0.65625 1.1875,1.21875 1.09375,2.5625 0.125,2.0625 -1.5,4.125 -1.9375,4.4375 -4.15625,7.46875 2.3125,-17.25 0.65625,-9.0625 -0.84375,-0.15625 -4.65625,31 -0.875,1.5625 -7.65625,14.40625 -9.78125,19.37499 -8.21875,16.8125 -4.5625,11.71875 -2.59375,-4.4375 1.625,-3.34375 8.9375,-17.15625 9.0625,-15.125 3.78125,-7.37499 3.125,-6.125 0.84375,-2.09375 0.1875,-2.03125 -0.375,-1.5625 h -0.375 l -0.28125,1.375 -1.5625,3.59375 -3.78125,6.375 -10.8125,16.62499 -6.15625,9.125 -4.21875,7.46875 2.59375,-25.71875 0.96875,-10.96874 0.40625,-23.1875 h -0.0625 l 0.18755,-0.78125 0.59375,-1.4375 0.46875,-1.3125 0.5625,-0.96875 v -1.90625 l -0.1875,-2.40625 0.84375,-1.5625 -0.375,-2.28125 v -1.71875 l 0.3125,-0.96875 0.65625,-2.15625 0.46875,-1.15625 -0.875,-1.4375 0.75,-1.4375 -1.1875,-0.84375 -0.71875,-2.15625 1.03125,-1.6875 -1.4375,-0.46875 -0.625,-1.125 v -0.96875 l -0.65625,-1.09375 -0.65625,-0.59375 0.0625,-0.90625 v -1 l -0.3125,-2.71875 -0.21875,-1.5625 -0.96875,-0.71875 -0.46875,-0.84375 -1.09375,-0.53125 -0.65625,-1.1875 0.125,-1.34375 -0.125,-1.375 -0.71875,-1.1875 -1.25,-0.25 -1.15625,-0.40625 -0.59375,-0.84375 -0.40625,-0.90625 -0.90625,0.59375 -0.375,1.15625 -0.1875,1.25 -0.59375,1.96875 -0.40625,-0.65625 0.1875,2.40625 -0.125,0.53125 v 0.90625 l 0.34375,0.71875 0.3125,0.96875 0.59375,0.78125 0.25,0.34375 0.1875,0.90625 -0.75,0.5625 0.3125,0.8125 -0.71875,0.90625 0.125,0.71875 0.1875,0.71875 0.59375,0.71875 0.53125,0.65625 0.71875,0.625 0.125,0.53125 -0.25,0.78125 -0.59375,0.53125 -0.28125,0.4375 0.0937,1.125 0.90625,0.59375 0.53125,0.5625 0.3125,1.125 -0.96875,1.15625 -0.15625,0.8125 0.40625,0.90625 0.59375,0.71875 v 0.71875 l 0.4375,0.5625 0.40625,0.46875 0.3125,0.53125 -0.1875,0.90625 0.59375,0.84375 0.53125,0.125 0.1875,0.40625 -0.1875,0.71875 0.5,1.03125 0.53125,0.40625 0.40625,0.84375 -0.40625,1.4375 0.59375,1.3125 0.5625,0.25 0.28125,0.59375 0.125,1.6875 -0.3125,0.71875 -0.28125,0.84375 0.84375,4.25 1.5,0.96875 -0.125,18.4375 -1.75,19.90624 -1.03125,11.53125 -1.6875,14 -0.65625,1.6875 -5.5625,-9.53125 -1.90625,-12.78125 -2.46875,-20.74999 -2.9375,-19.25 0.21875,17.5625 1.0313,14.53124 1.78125,13.84375 -12.40625,-19.65625 -17.8125,-26.71874 -4.09375,-5.6875 h -0.34375 l 1.1875,3.40625 2.21875,5.53125 3.25,7.375 5.6875,12.1875 3.4375,6.12499 4.25,7.375 8.78125,13.90625 7.9375,12.625 1.21875,11.3125 3.78125,25.84375 -0.002,-0.0161 -4.37265,-13.57769 -9.25,-22.78125 -7.375,-15.3125 -9.78125,-15.90625 -4.96875,-6.53124 -3.96875,-3.96875 -6.46875,-6 2.6875,3.3125 4.34375,4.4375 2.5625,2.87499 1.6875,2.9375 2.03125,3.25 3.3125,5.6875 2.875,5.28125 2.9375,6.53125 3.59375,8.71875 7.03125,18.1875 7.375,19.1875 4.4375,13.5625 z m -12.9406,-12.88394 -1.2869,-3.44454 -2.375,-4.5 -5.1875,-9.90625 -7.3125,-13.1875 -5.15625,-8.46875 -4.78125,-7.3125 -2.59375,-3.59375 -2.15625,-2.15625 3.71875,7.0625 3.40625,7.90625 5.125,11.65625 2.25,5.15625 2.25393,6.7029 z m -30.8494,-52.56954 -0.0625,-0.125 -0.1875,-0.125 z m 78.46875,-23.53124 -1.25,5.21874 -5.65625,22.625 -2.75,12.84375 -2.875,15.53125 -3.1875,10.125 -1.125,-2.625 -7.25,-13.4375 2.4375,-5.65625 7.9375,-16.625 4.25,-8.9375 5.6875,-12 z m 7.03125,16.84374 -1.03125,6 -2.9375,9.96875 -2.9375,7.375 -3.25,9.59375 -1.71875,9.4375 -1.625,10.0332 5.875,-5.9707 0.25,-3.0625 0.65625,-5.3125 1.5625,-7.5 3.40625,-13.40625 1.5625,-9.9375 z m -42.0625,27.34375 2.375,3.96875 -0.5,9.25 -0.375,0.28125 z m 4,6.65625 1.375,2.28125 -1.0625,2.5 -0.78125,0.5625 z"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 297.50037,539.11859 -3,3 22.53125,22.53125 -2.96875,2.96875 22.5,22.5 -3,3 38.46875,38.46875 38.5,-38.46875 -3,-3 22.5,-22.5 -2.96875,-2.96875 22.53125,-22.53125 -3,-3 -74.5625,74.53125 z"
+           id="path5410" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 372.03162,420.77484 -93.375,93.40625 93.375,93.40625 93.40625,-93.40625 z m 0,1.65625 91.75,91.75 -91.75,91.75 -91.75,-91.75 z"
+           id="path5412" />
+        <g
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="g5414"
+           transform="translate(268.5353,413.93109)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path5416"
+             d="m 30.875,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             d="m 115.83638,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             id="path5418"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         style="display:none;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:label="white_transparent"
+         id="g5420">
+        <rect
+           sodipodi:insensitive="true"
+           ry="15.09564"
+           rx="15.09564"
+           y="307.29431"
+           x="32.395325"
+           height="437.77356"
+           width="679.30383"
+           id="rect5422"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        <path
+           id="path5424"
+           d="m 367.81011,602.52854 4.21781,4.2809 1.43857,-1.54392 -2.57138,-19.15924 0.21875,-3.09375 1.3125,-4.625 1.375,-4.25 1.5,-3.34375 4.875,8.1875 4.75,8.65625 1.05469,5.08007 6.62885,-6.5039 3.34766,-25.16992 7.03125,-34.0625 4.53125,-23.12499 9.1875,-18.21875 1.375,-3.78125 0.5,-2.21875 0.1875,-3.59375 -0.5625,-2.875 -1.3125,-2.59375 -2.40625,-2.40625 0.125,0.65625 1.1875,1.21875 1.09375,2.5625 0.125,2.0625 -1.5,4.125 -1.9375,4.4375 -4.15625,7.46875 2.3125,-17.25 0.65625,-9.0625 -0.84375,-0.15625 -4.65625,31 -0.875,1.5625 -7.65625,14.40625 -9.78125,19.37499 -8.21875,16.8125 -4.5625,11.71875 -2.59375,-4.4375 1.625,-3.34375 8.9375,-17.15625 9.0625,-15.125 3.78125,-7.37499 3.125,-6.125 0.84375,-2.09375 0.1875,-2.03125 -0.375,-1.5625 h -0.375 l -0.28125,1.375 -1.5625,3.59375 -3.78125,6.375 -10.8125,16.62499 -6.15625,9.125 -4.21875,7.46875 2.59375,-25.71875 0.96875,-10.96874 0.40625,-23.1875 h -0.0625 l 0.18755,-0.78125 0.59375,-1.4375 0.46875,-1.3125 0.5625,-0.96875 v -1.90625 l -0.1875,-2.40625 0.84375,-1.5625 -0.375,-2.28125 v -1.71875 l 0.3125,-0.96875 0.65625,-2.15625 0.46875,-1.15625 -0.875,-1.4375 0.75,-1.4375 -1.1875,-0.84375 -0.71875,-2.15625 1.03125,-1.6875 -1.4375,-0.46875 -0.625,-1.125 v -0.96875 l -0.65625,-1.09375 -0.65625,-0.59375 0.0625,-0.90625 v -1 l -0.3125,-2.71875 -0.21875,-1.5625 -0.96875,-0.71875 -0.46875,-0.84375 -1.09375,-0.53125 -0.65625,-1.1875 0.125,-1.34375 -0.125,-1.375 -0.71875,-1.1875 -1.25,-0.25 -1.15625,-0.40625 -0.59375,-0.84375 -0.40625,-0.90625 -0.90625,0.59375 -0.375,1.15625 -0.1875,1.25 -0.59375,1.96875 -0.40625,-0.65625 0.1875,2.40625 -0.125,0.53125 v 0.90625 l 0.34375,0.71875 0.3125,0.96875 0.59375,0.78125 0.25,0.34375 0.1875,0.90625 -0.75,0.5625 0.3125,0.8125 -0.71875,0.90625 0.125,0.71875 0.1875,0.71875 0.59375,0.71875 0.53125,0.65625 0.71875,0.625 0.125,0.53125 -0.25,0.78125 -0.59375,0.53125 -0.28125,0.4375 0.0937,1.125 0.90625,0.59375 0.53125,0.5625 0.3125,1.125 -0.96875,1.15625 -0.15625,0.8125 0.40625,0.90625 0.59375,0.71875 v 0.71875 l 0.4375,0.5625 0.40625,0.46875 0.3125,0.53125 -0.1875,0.90625 0.59375,0.84375 0.53125,0.125 0.1875,0.40625 -0.1875,0.71875 0.5,1.03125 0.53125,0.40625 0.40625,0.84375 -0.40625,1.4375 0.59375,1.3125 0.5625,0.25 0.28125,0.59375 0.125,1.6875 -0.3125,0.71875 -0.28125,0.84375 0.84375,4.25 1.5,0.96875 -0.125,18.4375 -1.75,19.90624 -1.03125,11.53125 -1.6875,14 -0.65625,1.6875 -5.5625,-9.53125 -1.90625,-12.78125 -2.46875,-20.74999 -2.9375,-19.25 0.21875,17.5625 1.0313,14.53124 1.78125,13.84375 -12.40625,-19.65625 -17.8125,-26.71874 -4.09375,-5.6875 h -0.34375 l 1.1875,3.40625 2.21875,5.53125 3.25,7.375 5.6875,12.1875 3.4375,6.12499 4.25,7.375 8.78125,13.90625 7.9375,12.625 1.21875,11.3125 3.78125,25.84375 -0.002,-0.0161 -4.37265,-13.57769 -9.25,-22.78125 -7.375,-15.3125 -9.78125,-15.90625 -4.96875,-6.53124 -3.96875,-3.96875 -6.46875,-6 2.6875,3.3125 4.34375,4.4375 2.5625,2.87499 1.6875,2.9375 2.03125,3.25 3.3125,5.6875 2.875,5.28125 2.9375,6.53125 3.59375,8.71875 7.03125,18.1875 7.375,19.1875 4.4375,13.5625 z m -12.9406,-12.88394 -1.2869,-3.44454 -2.375,-4.5 -5.1875,-9.90625 -7.3125,-13.1875 -5.15625,-8.46875 -4.78125,-7.3125 -2.59375,-3.59375 -2.15625,-2.15625 3.71875,7.0625 3.40625,7.90625 5.125,11.65625 2.25,5.15625 2.25393,6.7029 z m -30.8494,-52.56954 -0.0625,-0.125 -0.1875,-0.125 z m 78.46875,-23.53124 -1.25,5.21874 -5.65625,22.625 -2.75,12.84375 -2.875,15.53125 -3.1875,10.125 -1.125,-2.625 -7.25,-13.4375 2.4375,-5.65625 7.9375,-16.625 4.25,-8.9375 5.6875,-12 z m 7.03125,16.84374 -1.03125,6 -2.9375,9.96875 -2.9375,7.375 -3.25,9.59375 -1.71875,9.4375 -1.625,10.0332 5.875,-5.9707 0.25,-3.0625 0.65625,-5.3125 1.5625,-7.5 3.40625,-13.40625 1.5625,-9.9375 z m -42.0625,27.34375 2.375,3.96875 -0.5,9.25 -0.375,0.28125 z m 4,6.65625 1.375,2.28125 -1.0625,2.5 -0.78125,0.5625 z"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 297.50037,539.11859 -3,3 22.53125,22.53125 -2.96875,2.96875 22.5,22.5 -3,3 38.46875,38.46875 38.5,-38.46875 -3,-3 22.5,-22.5 -2.96875,-2.96875 22.53125,-22.53125 -3,-3 -74.5625,74.53125 z"
+           id="path5426" />
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 372.03162,420.77484 -93.375,93.40625 93.375,93.40625 93.40625,-93.40625 z m 0,1.65625 91.75,91.75 -91.75,91.75 -91.75,-91.75 z"
+           id="path5428" />
+        <g
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="g5430"
+           transform="translate(268.5353,413.93109)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path5432"
+             d="m 30.875,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             d="m 115.83638,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             id="path5434"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g5436"
+         inkscape:label="white_opaque"
+         style="display:none;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect5438"
+           width="679.30383"
+           height="437.77356"
+           x="32.395325"
+           y="307.29431"
+           rx="15.09564"
+           ry="15.09564"
+           sodipodi:insensitive="true" />
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 367.81011,602.52854 4.21781,4.2809 1.43857,-1.54392 -2.57138,-19.15924 0.21875,-3.09375 1.3125,-4.625 1.375,-4.25 1.5,-3.34375 4.875,8.1875 4.75,8.65625 1.05469,5.08007 6.62885,-6.5039 3.34766,-25.16992 7.03125,-34.0625 4.53125,-23.12499 9.1875,-18.21875 1.375,-3.78125 0.5,-2.21875 0.1875,-3.59375 -0.5625,-2.875 -1.3125,-2.59375 -2.40625,-2.40625 0.125,0.65625 1.1875,1.21875 1.09375,2.5625 0.125,2.0625 -1.5,4.125 -1.9375,4.4375 -4.15625,7.46875 2.3125,-17.25 0.65625,-9.0625 -0.84375,-0.15625 -4.65625,31 -0.875,1.5625 -7.65625,14.40625 -9.78125,19.37499 -8.21875,16.8125 -4.5625,11.71875 -2.59375,-4.4375 1.625,-3.34375 8.9375,-17.15625 9.0625,-15.125 3.78125,-7.37499 3.125,-6.125 0.84375,-2.09375 0.1875,-2.03125 -0.375,-1.5625 h -0.375 l -0.28125,1.375 -1.5625,3.59375 -3.78125,6.375 -10.8125,16.62499 -6.15625,9.125 -4.21875,7.46875 2.59375,-25.71875 0.96875,-10.96874 0.40625,-23.1875 h -0.0625 l 0.18755,-0.78125 0.59375,-1.4375 0.46875,-1.3125 0.5625,-0.96875 v -1.90625 l -0.1875,-2.40625 0.84375,-1.5625 -0.375,-2.28125 v -1.71875 l 0.3125,-0.96875 0.65625,-2.15625 0.46875,-1.15625 -0.875,-1.4375 0.75,-1.4375 -1.1875,-0.84375 -0.71875,-2.15625 1.03125,-1.6875 -1.4375,-0.46875 -0.625,-1.125 v -0.96875 l -0.65625,-1.09375 -0.65625,-0.59375 0.0625,-0.90625 v -1 l -0.3125,-2.71875 -0.21875,-1.5625 -0.96875,-0.71875 -0.46875,-0.84375 -1.09375,-0.53125 -0.65625,-1.1875 0.125,-1.34375 -0.125,-1.375 -0.71875,-1.1875 -1.25,-0.25 -1.15625,-0.40625 -0.59375,-0.84375 -0.40625,-0.90625 -0.90625,0.59375 -0.375,1.15625 -0.1875,1.25 -0.59375,1.96875 -0.40625,-0.65625 0.1875,2.40625 -0.125,0.53125 v 0.90625 l 0.34375,0.71875 0.3125,0.96875 0.59375,0.78125 0.25,0.34375 0.1875,0.90625 -0.75,0.5625 0.3125,0.8125 -0.71875,0.90625 0.125,0.71875 0.1875,0.71875 0.59375,0.71875 0.53125,0.65625 0.71875,0.625 0.125,0.53125 -0.25,0.78125 -0.59375,0.53125 -0.28125,0.4375 0.0937,1.125 0.90625,0.59375 0.53125,0.5625 0.3125,1.125 -0.96875,1.15625 -0.15625,0.8125 0.40625,0.90625 0.59375,0.71875 v 0.71875 l 0.4375,0.5625 0.40625,0.46875 0.3125,0.53125 -0.1875,0.90625 0.59375,0.84375 0.53125,0.125 0.1875,0.40625 -0.1875,0.71875 0.5,1.03125 0.53125,0.40625 0.40625,0.84375 -0.40625,1.4375 0.59375,1.3125 0.5625,0.25 0.28125,0.59375 0.125,1.6875 -0.3125,0.71875 -0.28125,0.84375 0.84375,4.25 1.5,0.96875 -0.125,18.4375 -1.75,19.90624 -1.03125,11.53125 -1.6875,14 -0.65625,1.6875 -5.5625,-9.53125 -1.90625,-12.78125 -2.46875,-20.74999 -2.9375,-19.25 0.21875,17.5625 1.0313,14.53124 1.78125,13.84375 -12.40625,-19.65625 -17.8125,-26.71874 -4.09375,-5.6875 h -0.34375 l 1.1875,3.40625 2.21875,5.53125 3.25,7.375 5.6875,12.1875 3.4375,6.12499 4.25,7.375 8.78125,13.90625 7.9375,12.625 1.21875,11.3125 3.78125,25.84375 -0.002,-0.0161 -4.37265,-13.57769 -9.25,-22.78125 -7.375,-15.3125 -9.78125,-15.90625 -4.96875,-6.53124 -3.96875,-3.96875 -6.46875,-6 2.6875,3.3125 4.34375,4.4375 2.5625,2.87499 1.6875,2.9375 2.03125,3.25 3.3125,5.6875 2.875,5.28125 2.9375,6.53125 3.59375,8.71875 7.03125,18.1875 7.375,19.1875 4.4375,13.5625 z m -12.9406,-12.88394 -1.2869,-3.44454 -2.375,-4.5 -5.1875,-9.90625 -7.3125,-13.1875 -5.15625,-8.46875 -4.78125,-7.3125 -2.59375,-3.59375 -2.15625,-2.15625 3.71875,7.0625 3.40625,7.90625 5.125,11.65625 2.25,5.15625 2.25393,6.7029 z m -30.8494,-52.56954 -0.0625,-0.125 -0.1875,-0.125 z m 78.46875,-23.53124 -1.25,5.21874 -5.65625,22.625 -2.75,12.84375 -2.875,15.53125 -3.1875,10.125 -1.125,-2.625 -7.25,-13.4375 2.4375,-5.65625 7.9375,-16.625 4.25,-8.9375 5.6875,-12 z m 7.03125,16.84374 -1.03125,6 -2.9375,9.96875 -2.9375,7.375 -3.25,9.59375 -1.71875,9.4375 -1.625,10.0332 5.875,-5.9707 0.25,-3.0625 0.65625,-5.3125 1.5625,-7.5 3.40625,-13.40625 1.5625,-9.9375 z m -42.0625,27.34375 2.375,3.96875 -0.5,9.25 -0.375,0.28125 z m 4,6.65625 1.375,2.28125 -1.0625,2.5 -0.78125,0.5625 z"
+           id="path5440" />
+        <path
+           id="path5442"
+           d="m 297.50037,539.11859 -3,3 22.53125,22.53125 -2.96875,2.96875 22.5,22.5 -3,3 38.46875,38.46875 38.5,-38.46875 -3,-3 22.5,-22.5 -2.96875,-2.96875 22.53125,-22.53125 -3,-3 -74.5625,74.53125 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path5444"
+           d="m 372.03162,420.77484 -93.375,93.40625 93.375,93.40625 93.40625,-93.40625 z m 0,1.65625 91.75,91.75 -91.75,91.75 -91.75,-91.75 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <g
+           transform="translate(268.5353,413.93109)"
+           id="g5446"
+           style="display:inline;vector-effect:none;fill:#000000;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1">
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+             d="m 30.875,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             id="path5448"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5450"
+             d="m 115.83638,210.40625 v 1.25 h 60.3125 v -1.25 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -421,7 +421,7 @@ pre {
   width: 100%;
   top: 0;
   left: 0;
-  background: rgb(5, 83, 32, 0.5);
+  background: var(--primary-color);
 }
 .overlayg {
   position: relative;
@@ -670,7 +670,7 @@ pre {
 }
 
 .gitter-banner {
-  background: linear-gradient(45deg, var(--grass-color-dark) 0%, var(--grass-color) 50%,var(--grass-color-dark) 100%); 
+  background: var(--primary-color);
   text-align: center;
   color:whitesmoke;
   font-weight: bolder;

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -421,10 +421,7 @@ pre {
   width: 100%;
   top: 0;
   left: 0;
-  background: -moz-linear-gradient(top, rgba(255, 255, 255, 1) 12%, rgba(255, 255, 255, 0.47) 59%, rgba(255, 255, 255, 0) 100%);
-  background: -webkit-linear-gradient(top, rgba(255, 255, 255, 1) 12%, rgba(255, 255, 255, 0.47) 59%, rgba(255, 255, 255, 0) 100%);
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 1) 12%, rgba(255, 255, 255, 0.47) 59%, rgba(255, 255, 255, 0) 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#00ffffff', GradientType=0);
+  background: rgb(5, 83, 32, 0.5);
 }
 .overlayg {
   position: relative;
@@ -648,9 +645,9 @@ pre {
   background: transparent;
 }
 .banner p {
-  font-size: 24px;
-  color: #000000;
-  background: rgba(255, 255, 255, .45)
+  font-family: open_sansbold;
+  font-size: 22px;
+  color: #ffffff;
 }
 .banner .text-dark {
   color: var(--dark-color);

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -1,6 +1,6 @@
   {{ partial "head.html" . }}
 
-  <header class="hero-section overlay bg-cover banner" data-background="{{.Site.BaseURL}}/images/logos/banner.jpg">
+  <header class="hero-section overlay bg-cover banner">
     <div class="fixed-top">
       {{ partial "banner.html" . }}
       <div class="bg-white">

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -13,8 +13,8 @@
         <div class="container">
         <div class="row">
             <div class="col-lg-8 text-center mx-auto">
-            <h1 class="mb-3"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grasslogo.svg" width="25%"></h1>{{ with .Site.Params.banner.description }}
-            <p class=" text-bold mb-4">{{ . }}</p>{{ end }}
+            <h1 class="mb-3"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grass_gis.svg" width="25%"></h1>{{ with .Site.Params.banner.description }}
+            <p class="mb-4">{{ . }}</p>{{ end }}
             </div>
         </div>
         </div>


### PR DESCRIPTION
This uses a single color inverted logo in white (the grass plant is transparent, its background is white, everything else is white too).

The mission text is in bold font used for headings and is white and little smaller. It does not have to use the background box for contrast anymore.

The grass photo in the background is not covered in gradient to white, but with transparent dark green overlay for contrast with white and for matching the green in the top bar.


![Screenshot from 2024-09-04 23-02-22](https://github.com/user-attachments/assets/60c6ba24-e7e5-49f6-a4ff-79d955332495)