### PR TITLE
Update Development Quick links URLs

### DIFF
--- a/themes/grass/layouts/contribute/devel.html
+++ b/themes/grass/layouts/contribute/devel.html
@@ -34,8 +34,8 @@
                 <li><i class="ms ms-grass-gis"></i> &#160;<a href="https://github.com/OSGeo/grass/blob/master/CONTRIBUTING.md" target="_blank">How to contribute</a></li>
                 <li><i class="fa fa-gears"></i> &#160;<a href="https://grasswiki.osgeo.org/wiki/GRASS_GIS_APIs" target="_blank">API's wiki page</a></li>
                 <li><i class="fa fa-file-text"></i> &#160;<a href="https://grass.osgeo.org/programming8/" target="_blank">Developer manual</a></li>
-                <li><i class="fa fa-code"></i> &#160;<a href="https://trac.osgeo.org/grass/wiki/Submitting" target="_blank">Submitting guidelines</a></li>
-                <li><i class="fa fa-code-fork"></i> &#160;<a href="https://trac.osgeo.org/grass/wiki/HowToGit" target="_blank">How to use git</a></li>
+                <li><i class="fa fa-code"></i> &#160;<a href="https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md" target="_blank">Programming style guide</a></li>
+                <li><i class="fa fa-code-fork"></i> &#160;<a href="https://github.com/OSGeo/grass/blob/main/doc/development/github_guide.md" target="_blank">How to use git</a></li>
 	        <li><i class="fab fa-github"></i> &#160;<a href="https://github.com/OSGeo/grass/" target="_blank">Source code</a></li>
                 <li><i class="fa fa-user-gear"></i> &#160;<a href="https://grasswiki.osgeo.org/wiki/Compile_and_Install" target="_blank">Compile GRASS GIS</a></li>
 	        <li><i class="fa fa-bug"></i> &#160;<a href="https://github.com/OSGeo/grass/issues" target="_blank">Bug Tracker</a></li>


### PR DESCRIPTION
Update "Development Quick links" to not point to trac but to GitHub.

Fixes #472

https://grass.osgeo.org/contribute/development/

![image](https://github.com/user-attachments/assets/aeefdfc0-437f-479f-a628-2ea5fa26634b)
