### PR TITLE
Added contributor recruitment message to console

### DIFF
--- a/themes/grass/assets/js/contributor_ad.js
+++ b/themes/grass/assets/js/contributor_ad.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+const header = `
+   __________  ___   __________    _______________
+  / ____/ __ \\/   | / ___/ ___/   / ____/  _/ ___/
+ / / __/ /_/ / /| | \\__ \\\\_  \\   / / __ / / \\__ \\
+/ /_/ / _, _/ ___ |___/ /__/ /  / /_/ // / ___/ /
+\\____/_/ |_/_/  |_/____/____/   \\____/___//____/
+
+`;
+    console.log(header);
+    const message = "Curious about GRASS GIS? Consider contributing or join our mentoring program!";
+    console.log(message);
+    const link = "https://grass.osgeo.org/contribute/development/";
+    console.log(link);
+});

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -29,8 +29,13 @@
 <script src="{{ .Site.BaseURL }}plugins/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 <script src="{{ .Site.BaseURL }}plugins/gallery/photoswipe.js"></script>
-{{ $script := resources.Get "js/script.js" | minify}}
-{{ $script := resources.Get "js/contributor_ad.js"}}
-<script src="{{ $script.Permalink }}"></script>
+
+<!-- Bundle, minifiy and fingerprint js assets before loading -->
+{{ $contrib := resources.Get "js/contributor_ad.js" }}
+{{ $script := resources.Get "js/script.js" }}
+{{ $js := slice $contrib $script | resources.Concat "js/bundle.js" | minify }}
+{{ $secureJS := $js | resources.Fingerprint "sha512" }}
+<script src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+
 </body>
 </html>

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -28,7 +28,9 @@
 <script src="{{ .Site.BaseURL }}plugins/bootstrap/bootstrap.min.js"></script>
 <script src="{{ .Site.BaseURL }}plugins/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script src="{{ .Site.BaseURL }}plugins/gallery/photoswipe.js"></script>{{ $script := resources.Get "js/script.js" | minify}}
+<script src="{{ .Site.BaseURL }}plugins/gallery/photoswipe.js"></script>
+{{ $script := resources.Get "js/script.js" | minify}}
+{{ $script := resources.Get "js/contributor_ad.js"}}
 <script src="{{ $script.Permalink }}"></script>
 </body>
 </html>


### PR DESCRIPTION
I've added code to display the follwing message to potential contributors who are looking at the websites console logs.

```bash

   __________  ___   __________    _______________
  / ____/ __ \/   | / ___/ ___/   / ____/  _/ ___/
 / / __/ /_/ / /| | \__ \\_  \   / / __ / / \__ \
/ /_/ / _, _/ ___ |___/ /__/ /  / /_/ // / ___/ /
\____/_/ |_/_/  |_/____/____/   \____/___//____/



Curious about GRASS GIS? Consider contributing or join our mentoring program!
https://grass.osgeo.org/contribute/development/

```