### PR TITLE
sitemap.xml: switch from versioned manual URLs to stable/devel

### DIFF
--- a/themes/grass/layouts/_default/home.sitemap.xml
+++ b/themes/grass/layouts/_default/home.sitemap.xml
@@ -4,12 +4,12 @@
       <loc>https://grass.osgeo.org/sitemap_hugo.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass-stable/manuals/sitemap_manuals.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass{{- .Site.Data.grass.current_version_nodots -}}/manuals/addons/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass-stable/manuals/addons/sitemap_manuals.xml</loc>
    </sitemap>
    <sitemap>
-      <loc>https://grass.osgeo.org/grass{{- .Site.Data.grass.preview_version_nodots -}}/manuals/sitemap_manuals.xml</loc>
+      <loc>https://grass.osgeo.org/grass-devel/manuals/sitemap_manuals.xml</loc>
    </sitemap>
 </sitemapindex>


### PR DESCRIPTION
So far https://grass.osgeo.org/sitemap.xml showed the versioned manual pages which is unhelpful in terms of consolidating search engine results for manuals. In the past months we were penalized by "duplicate content".

For an overview, see https://github.com/OSGeo/grass/issues/4579

For efforts to address this situation, see

- https://github.com/OSGeo/grass-addons/pull/1168
- https://github.com/OSGeo/grass-addons/pull/1241

This PR changes the URL in `sitemap.xml` from versioned manual URLs to grass-stable/grass-devel in order to complete the other PRs.

This also makes the manual "landing" independent from the actual version.