### PR TITLE
Fix the issue icons cover the content of the page on mobile

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -1327,7 +1327,11 @@ code{
   background: rgba(255, 255, 255, 0.8)
   /* background: radial-gradient(circle, var(--white-color) 80%, transparent 90%); */
 }
-
+@media (max-width: 992px) {
+  .col-2 i {
+    font-size: 3rem;
+    }
+}
 @media (max-width: 576px) {
 
   body {
@@ -1394,12 +1398,12 @@ code{
     padding-bottom: 0px;
   }
 
+  .col-2 i {
+    font-size: 1.5rem;
+    }
+
   .mb-40 {
     margin-bottom: 20px !important;
-  }
-
-  .col-2.text-center {
-    display: none;
   }
 
   #links li span a {

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -1398,6 +1398,10 @@ code{
     margin-bottom: 20px !important;
   }
 
+  .col-2.text-center {
+    display: none;
+  }
+
   #links li span a {
     font-size: 15px !important;
   }


### PR DESCRIPTION
In this fix, I addressed the issue where large icons were overlapping the content on mobile devices, creating a poor user experience. By using a CSS media query targeting screens with a maximum width of 570px, I applied the display: none; property to the specific icon container. This ensures that the icons are hidden on smaller screens, preventing them from covering other content and improving the overall layout and usability of the page