### PR TITLE
add linkedin logo to footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -286,6 +286,9 @@ greyColorDark = "#A0A0A0"
     [[Languages.en.params.socialIcon]]
       icon = "fab fa-youtube"
       link = "https://www.youtube.com/@grass-gis"
+    [[Languages.en.params.socialIcon]]
+      icon = "fab fa-linkedin"
+      link = "https://www.linkedin.com/company/grass-gis/"
       
     [[Languages.en.params.socialIcon]]
       icon = "fa fa-rss"


### PR DESCRIPTION
fixes#498
Added linkedin logo to the footer 
made changes to config.toml
![Screenshot 2025-03-02 220516](https://github.com/user-attachments/assets/c0ebc541-3a01-449e-9bbd-ca6bae1158c1)
