### PR TITLE
Added linkdin logo to footer 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -272,6 +272,10 @@ greyColorDark = "#A0A0A0"
           link = "https://gitter.im/grassgis/community"
 
     [[Languages.en.params.socialIcon]]
+      icon = "fab fa-linkedin"
+      link = "https://www.linkedin.com/company/grass-gis/"
+
+    [[Languages.en.params.socialIcon]]
       icon = " fab fa-mastodon"
       link = "https://fosstodon.org/@grassgis"
 
@@ -286,9 +290,6 @@ greyColorDark = "#A0A0A0"
     [[Languages.en.params.socialIcon]]
       icon = "fab fa-youtube"
       link = "https://www.youtube.com/@grass-gis"
-    [[Languages.en.params.socialIcon]]
-      icon = "fab fa-linkedin"
-      link = "https://www.linkedin.com/company/grass-gis/"
       
     [[Languages.en.params.socialIcon]]
       icon = "fa fa-rss"

--- a/config.toml
+++ b/config.toml
@@ -286,6 +286,9 @@ greyColorDark = "#A0A0A0"
     [[Languages.en.params.socialIcon]]
       icon = "fab fa-youtube"
       link = "https://www.youtube.com/@grass-gis"
+    [[Languages.en.params.socialIcon]]
+      icon = "fab fa-linkedin"
+      link = "https://www.linkedin.com/company/grass-gis/"
       
     [[Languages.en.params.socialIcon]]
       icon = "fa fa-rss"

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -15,14 +15,19 @@
 	<p><small><a href="https://github.com/OSGeo/grass-website/tree/master/content/{{ .Section }}/{{ with .File }}{{ .BaseFileName }}{{ end }}.md" class="fab fa-github"> <span class="edt">Edit this page on GitHub</span></a></small></p>
   {{end}}
       </div>
-      <div class="col-md-4 text-md-right text-center">	
-	<ul class="list-inline mb-3">
-          {{ range .Site.Params.socialIcon }}
-          <li class="list-inline-item"><a class="text-color d-inline-block p-2" href="{{ .link }}"><i class="{{ .icon }}"></i></a></li>
-          {{ end }}
-        </ul>
-      </div>
-    </div>
+<div class="col-md-4 text-md-right text-center">	
+  <ul class="list-inline mb-3 d-flex justify-content-center justify-content-md-end align-items-center">
+    {{ range .Site.Params.socialIcon }}
+      <li class="list-inline-item d-flex align-items-center">
+        <a class="text-color d-inline-block p-2" href="{{ .link }}">
+          <i class="{{ .icon }}"></i>
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+</div>
+</div>
+
   </div>
 </footer>
 <script src="{{ .Site.BaseURL }}plugins/bootstrap/bootstrap.min.js"></script>


### PR DESCRIPTION
Fixes #498
Added LinkedIn logo to the footer between gitter and fosstodon.
Made changes to config.toml
![Screenshot 2025-03-02 221103](https://github.com/user-attachments/assets/9fc75ce6-03fe-4334-803c-bf7f96fc0f40)
