### PR TITLE
mirrors: cleanup of mirrors

### DIFF
--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -4,27 +4,27 @@ date: 2025-05-11T10:12:05+02:00
 layout: "general"
 ---
 
-### Official main site via HTTP/FTP
+### Official main site
 
 * [Official main site: grass.osgeo.org](https://grass.osgeo.org/) (Portland, USA)
 
 ### African Web site mirrors
 
-* [South Africa](https://grass.mirror.ac.za/) (Tier 1,TENET)
-* [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
+* [Morocco](https://grass.marwan.ma/) (Tier 1, Moroccan National Research and Education Network, MARWAN)
+* [South Africa](https://grass.mirror.ac.za/) (Tier 1, TENET)
 
 ### European Web site mirrors
 
-* [Italy](https://grass.mirror.download.it) (Tier 1)
+* [Italy](https://grass.mirror.download.it) (Tier 1, Download.it)
 
 ### US Web site mirrors
 
-- [USA](https://mirrors.ibiblio.org/grass/html/) (Tier 1)
+- [USA](https://mirrors.ibiblio.org/grass/html/) (Tier 1, ibiblio)
 
 ### Mirror our website
 
 If you would like to support the GRASS community, do not hesitate to set up your mirror site.
-Please consider to [contact us](mailto:grass-web(at)lists.osgeo.org), ideally reporting your [already running mirror](/about/mirrors/).
+Please consider to [contact us](/support/), ideally reporting your [already running mirror](/about/mirrors/).
 
 #### Requirements:
 A GRASS mirror site requires around 23 GB space, the space requirements may vary due to the changing presence of precompiled binaries.
@@ -54,4 +54,4 @@ The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync
   * `/usr/bin/rsync -az --port=50026 grass.osgeo.org::grass-website /var/www/html/mirror/grass-website`
   * This will copy/update the GRASS site to your local directory /var/www/html/mirror/grass-website/ which needs to be made available in your web server.
 * Check if the synchronization works the next day(s).
-* Announce the new mirror site for this mirror list to [us](mailto:grass-web(at)lists.osgeo.org).
+* Tell [us](/support/) about your new mirror site.

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -14,16 +14,16 @@ layout: "general"
 
 ### African Web site mirrors
 
-- [Morocco](https://grass.marwan.ma/) (Tier 1, Moroccan National Research and Education Network, MARWAN)
-- [South Africa](https://grass.mirror.ac.za/) (Tier 1, TENET)
+- [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
+- [South Africa](https://grass.mirror.ac.za/) (TENET)
 
 ### European Web site mirrors
 
-- [Italy](https://grass.mirror.download.it) (Tier 1, Download.it)
+- [Italy](https://grass.mirror.download.it) (Download.it)
 
 ### US Web site mirrors
 
-- [USA](https://mirrors.ibiblio.org/grass/html/) (Tier 1, ibiblio)
+- [USA](https://mirrors.ibiblio.org/grass/html/) (ibiblio)
 
 ### Mirror our website
 

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -1,21 +1,25 @@
 ---
-title: "GRASS GIS Website mirrors"
-date: 2025-05-11T10:12:05+02:00
+title: " GRASS Website mirrors"
+date: 2025-05-14T10:12:05+02:00
 layout: "general"
 ---
 
-### Official main site
+# GRASS Website mirrors
 
-* [Official main site: grass.osgeo.org](https://grass.osgeo.org/) (Portland, USA)
+## Official main site
+
+- [Official main site: grass.osgeo.org](https://grass.osgeo.org/) (Portland, USA)
+
+## Mirror sites
 
 ### African Web site mirrors
 
-* [Morocco](https://grass.marwan.ma/) (Tier 1, Moroccan National Research and Education Network, MARWAN)
-* [South Africa](https://grass.mirror.ac.za/) (Tier 1, TENET)
+- [Morocco](https://grass.marwan.ma/) (Tier 1, Moroccan National Research and Education Network, MARWAN)
+- [South Africa](https://grass.mirror.ac.za/) (Tier 1, TENET)
 
 ### European Web site mirrors
 
-* [Italy](https://grass.mirror.download.it) (Tier 1, Download.it)
+- [Italy](https://grass.mirror.download.it) (Tier 1, Download.it)
 
 ### US Web site mirrors
 
@@ -26,32 +30,48 @@ layout: "general"
 If you would like to support the GRASS community, do not hesitate to set up your mirror site.
 Please consider to [contact us](/support/), ideally reporting your [already running mirror](/about/mirrors/).
 
-#### Requirements:
+## Requirements
+
 A GRASS mirror site requires around 23 GB space, the space requirements may vary due to the changing presence of precompiled binaries.
 
-#### How to set up a mirror site:
+### How to set up a mirror site
 
 The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](https://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using the "rsync" mirror software is that only changed files are transferred after the initial synchronization which minimizes the network traffic.
 
-#### Mirror site setup in greater detail:
+### Mirror site setup in greater detail
 
-* Install the rsync software.
-* Check if you can connect - note the two '::' characters:
-  * `rsync -az --port=50026 grass.osgeo.org::`
-  * This command should display the following welcome message:
+- Install the rsync software.
+- Check if you can connect - note the two '::' characters:
 
-```
-      GRASS GIS Website
-      grass-website  	GRASS GIS Website
+```sh
+rsync -az --port=50026 grass.osgeo.org::
 ```
 
-* Now generate a mirror folder on your server where to store the GRASS GIS website copy. We assume `/var/www/html/mirror/`:
-  * `mkdir /var/www/html/mirror/`
-* Change into this folder and copy the website into the subfolder `grass-website`:
-  * `cd /var/www/html/mirror/`
-  * `rsync -az --port=50026 grass.osgeo.org::grass-website grass-website`
-* Once finished, define a daily cron-job (in 'crontab') for rsync (example):
-  * `/usr/bin/rsync -az --port=50026 grass.osgeo.org::grass-website /var/www/html/mirror/grass-website`
-  * This will copy/update the GRASS site to your local directory /var/www/html/mirror/grass-website/ which needs to be made available in your web server.
-* Check if the synchronization works the next day(s).
-* Tell [us](/support/) about your new mirror site.
+- This command should display the following welcome message:
+
+```
+      GRASS Website
+      grass-website  	 GRASS Website
+```
+
+- Now generate a mirror folder on your server where to store the GRASS website copy. We assume `/var/www/html/mirror/`:
+
+```sh
+mkdir /var/www/html/mirror/
+```
+
+- Change into this folder and copy the website into the subfolder `grass-website`:
+
+```sh
+cd /var/www/html/mirror/
+rsync -az --port=50026 grass.osgeo.org::grass-website grass-website
+```
+
+- Once finished, define a daily cron-job (in 'crontab') for rsync (example). This will copy/update the GRASS site to your local directory /var/www/html/mirror/grass-website/ which needs to be made available in your web server.
+
+```sh
+/usr/bin/rsync -az --port=50026 grass.osgeo.org::grass-website /var/www/html/mirror/grass-website
+```
+
+- Check if the synchronization works the next day(s).
+- Tell [us](/support/) about your new mirror site.

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -1,6 +1,6 @@
 ---
 title: "GRASS GIS Website mirrors"
-date: 2022-05-28T10:12:05+02:00
+date: 2025-05-11T10:12:05+02:00
 layout: "general"
 ---
 
@@ -13,18 +13,16 @@ layout: "general"
 * [South Africa](https://grass.mirror.ac.za/) (Tier 1,TENET)
 * [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
 
-### Asian-Indian Web site mirrors
-
-* [India](http://wgbis.ces.iisc.ernet.in/grass/) (Tier 2, Indian Institute of Science, Bangalore)
-<!-- * [Japan](http://wgrass.media.osaka-cu.ac.jp/grassh/) (Tier 2, Osaka City University) -->
-<!-- * [South Korea](http://pinus.gntech.ac.kr/grass/) (Tier 2, Gyung-Nam National University of Science &amp; Technology) -->
-
 ### European Web site mirrors
 
-* [Italy](http://grass.mirror.download.it) (Tier 1)
-<!-- * [Czech Republic](http://grass.fsv.cvut.cz) (Tier 2, Czech Technical University in Prague, Department of Geomatics) -->
+* [Italy](https://grass.mirror.download.it) (Tier 1)
+
+### US Web site mirrors
+
+- [USA](https://mirrors.ibiblio.org/grass/html/) (Tier 1)
 
 ### Mirror our website
+
 If you would like to support the GRASS community, do not hesitate to set up your mirror site.
 Please consider to [contact us](mailto:grass-web(at)lists.osgeo.org), ideally reporting your [already running mirror](/about/mirrors/).
 
@@ -33,18 +31,20 @@ A GRASS mirror site requires around 23 GB space, the space requirements may vary
 
 #### How to set up a mirror site:
 
-The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](http://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using the "rsync" mirror software is that only changed files are transferred after the initial synchronization which minimizes the network traffic.
+The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](https://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using the "rsync" mirror software is that only changed files are transferred after the initial synchronization which minimizes the network traffic.
 
 #### Mirror site setup in greater detail:
 
 * Install the rsync software.
 * Check if you can connect - note the two '::' characters:
   * `rsync -az --port=50026 grass.osgeo.org::`
-  *  This command should display the following welcome message:
+  * This command should display the following welcome message:
+
 ```
       GRASS GIS Website
       grass-website  	GRASS GIS Website
 ```
+
 * Now generate a mirror folder on your server where to store the GRASS GIS website copy. We assume `/var/www/html/mirror/`:
   * `mkdir /var/www/html/mirror/`
 * Change into this folder and copy the website into the subfolder `grass-website`:

--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -12,25 +12,17 @@ layout: "general"
 
 ## Mirror sites
 
-### African Web site mirrors
-
 - [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
 - [South Africa](https://grass.mirror.ac.za/) (TENET)
-
-### European Web site mirrors
-
 - [Italy](https://grass.mirror.download.it) (Download.it)
-
-### US Web site mirrors
-
 - [USA](https://mirrors.ibiblio.org/grass/html/) (ibiblio)
 
-### Mirror our website
+## Mirror our website
 
 If you would like to support the GRASS community, do not hesitate to set up your mirror site.
 Please consider to [contact us](/support/), ideally reporting your [already running mirror](/about/mirrors/).
 
-## Requirements
+### Requirements
 
 A GRASS mirror site requires around 23 GB space, the space requirements may vary due to the changing presence of precompiled binaries.
 
@@ -38,12 +30,12 @@ A GRASS mirror site requires around 23 GB space, the space requirements may vary
 
 The main site hosted at OSGeo (grass.osgeo.org) can be mirrored with the ["rsync"](https://rsync.samba.org/) software protocol, allowing to synchronize mirrors automatically overnight. The idea of using the "rsync" mirror software is that only changed files are transferred after the initial synchronization which minimizes the network traffic.
 
-### Mirror site setup in greater detail
+#### Mirror site setup in greater detail
 
-- Install the rsync software.
-- Check if you can connect - note the two '::' characters:
+- Install the `rsync` software.
+- Check if you can connect - note the two `::` characters:
 
-```sh
+```
 rsync -az --port=50026 grass.osgeo.org::
 ```
 
@@ -56,20 +48,20 @@ rsync -az --port=50026 grass.osgeo.org::
 
 - Now generate a mirror folder on your server where to store the GRASS website copy. We assume `/var/www/html/mirror/`:
 
-```sh
+```
 mkdir /var/www/html/mirror/
 ```
 
 - Change into this folder and copy the website into the subfolder `grass-website`:
 
-```sh
+```
 cd /var/www/html/mirror/
 rsync -az --port=50026 grass.osgeo.org::grass-website grass-website
 ```
 
 - Once finished, define a daily cron-job (in 'crontab') for rsync (example). This will copy/update the GRASS site to your local directory /var/www/html/mirror/grass-website/ which needs to be made available in your web server.
 
-```sh
+```
 /usr/bin/rsync -az --port=50026 grass.osgeo.org::grass-website /var/www/html/mirror/grass-website
 ```
 


### PR DESCRIPTION
- added IBIBLIO mirror (USA)
- removed Indian mirror page as it is nowadays just an `iframe` of the original site
- removed old commented-out server entries
- update of http to https where needed
- cleanup "Tier 1" entries, add missing mirroring institutions
- replace "grass-web(at)lists.osgeo.org" with https://grass.osgeo.org/support/