### PR TITLE
SEO: Added aria-labels to social links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -253,35 +253,45 @@ title = "Geographic Resources Analysis Support System"
 [[Languages.en.params.socialIcon]]
 icon = " fab fa-github"
 link = "https://github.com/OSGeo/grass"
+label = "GRASS on GitHub"
 
 [[Languages.en.params.socialIcon]]
 icon = " fab fa-discourse"
 link = "https://discourse.osgeo.org/c/grass/62"
+label = "GRASS Discourse"
 
 [[Languages.en.params.socialIcon]]
 icon = " fa fa-comments"
 link = "https://gitter.im/grassgis/community"
+label = "GRASS Gitter Community"
 
 [[Languages.en.params.socialIcon]]
 icon = "fab fa-linkedin"
 link = "https://www.linkedin.com/company/grass-gis/"
+label = "GRASS on LinkedIn"
 
 [[Languages.en.params.socialIcon]]
 icon = " fab fa-mastodon"
 link = "https://fosstodon.org/@grassgis"
+label = "GRASS on Mastodon"
 
 [[Languages.en.params.socialIcon]]
 icon = " fab fa-x-twitter"
 link = "https://twitter.com/grassgis"
+label = "GRASS on Twitter/X"
 
 [[Languages.en.params.socialIcon]]
 icon = "fab fa-facebook"
 link = "https://www.facebook.com/groups/GRASS"
+label = "GRASS on Facebook"
 
 [[Languages.en.params.socialIcon]]
 icon = "fab fa-youtube"
 link = "https://www.youtube.com/@grass-gis"
+label = "GRASS YouTube Channel"
 
 [[Languages.en.params.socialIcon]]
 icon = "fa fa-rss"
 link = "https://grass.osgeo.org/index.xml"
+label = "RSS Feed"
+

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -19,7 +19,7 @@
     <ul class="list-inline mb-3 d-flex justify-content-center justify-content-md-end align-items-center">
       {{ range .Site.Params.socialIcon }}
         <li class="list-inline-item d-flex align-items-center">
-          <a class="color-secondary d-inline-block p-2" href="{{ .link }}">
+          <a class="color-secondary d-inline-block p-2" aria-label="{{ .label }}" href="{{ .link }}">
             <i class="{{ .icon }}"></i>
           </a>
         </li>


### PR DESCRIPTION
I've added an `aria-label` attribute to each of the social links in the footer to address Issue https://github.com/OSGeo/grass-website/issues/518.