### PR TITLE
Replace grass-dev mailing list with GRASS Dev on Discourse

### DIFF
--- a/content/contribute/_index.en.md
+++ b/content/contribute/_index.en.md
@@ -56,7 +56,7 @@ found in [this document](https://trac.osgeo.org/grass/wiki/HowToContribute#Write
 The GRASS GIS core consists of libraries, tools and the Graphic User Interface.
 A good starting point is supporting us with [bug fixing and enhancement wishes](https://github.com/OSGeo/grass/issues).
 Review these [resources](/contribute/development) to learn how to develop and contribute code effectively.
-Feel free to announce your planned development to the [GRASS developers mailing list](https://lists.osgeo.org/mailman/listinfo/grass-dev), someone may join you or give you feedback.
+Feel free to announce your planned development to the [GRASS developers community](https://discourse.osgeo.org/c/grass/developer/61) on Discourse, someone may join you or give you feedback.
 
 For **paid opportunities** to develop code for GRASS GIS, check out our [stipend program](https://grasswiki.osgeo.org/wiki/Student_Grants) for students
 and [Google Summer of Code](https://summerofcode.withgoogle.com) program for students and open source beginners with our [list of ideas](https://trac.osgeo.org/grass/wiki/GSoC).

--- a/themes/grass/layouts/contribute/devel.html
+++ b/themes/grass/layouts/contribute/devel.html
@@ -41,7 +41,7 @@
 	        <li><i class="fa fa-bug"></i> &#160;<a href="https://github.com/OSGeo/grass/issues" target="_blank">Bug Tracker</a></li>
                 <li><i class="fa fa-file-code"></i> &#160;<a href="https://github.com/wenzeslaus/foss4g-2022-developing-custom-grass-tools" target="_blank">Write your own tools</a></li>
                 <li><i class="fab fa-github"></i> &#160;<a href="https://github.com/OSGeo/grass/discussions" target="_blank">GitHub Discussions</a></li>
-	        <li><i class="fa fa-envelope"></i> &#160;<a href="https://lists.osgeo.org/listinfo/grass-dev" target="_blank">GRASS Developers Mailing list</a></li>
+	        <li><i class="fab fa-discourse"></i> &#160;<a href="https://discourse.osgeo.org/c/grass/developer/61" target="_blank">GRASS Devs on Discourse</a></li>
              </ul>
           </div>
 	 </div>


### PR DESCRIPTION
I replaced the remaining occurrences of the grass-dev mailing list with the new Discourse GRASS dev community. 