### PR TITLE
history: expand GRASS acronym

### DIFF
--- a/content/about/brand.md
+++ b/content/about/brand.md
@@ -1,10 +1,10 @@
 ---
 title: "Brand"
-date: 2018-12-29T11:02:05+06:00
+date: 2025-05-15T11:02:05+06:00
 layout: "brand"
 ---
 
-<span style="font-size:1.25em;" class="text-secondary">Whether you are contributing to GRASS or creating materials which involve GRASS, help the project by keeping these branding guidelines</span>
+<span style="font-size:1.25em;" class="text-secondary">Whether you are contributing to GRASS or creating materials which involve GRASS, help the project by keeping these branding guidelines.</span>
 
 ## Logos
 

--- a/content/about/history.md
+++ b/content/about/history.md
@@ -21,7 +21,7 @@ layout: "general"
 <div class="col-lg-8 col-sm-12">
 <p>GRASS (Geographic Resources Analysis Support System) has been under continuous development since <b>1982</b>, when the U.S. Army Corps of Engineers' Construction Engineering Research Laboratory (USA/CERL)
 started exploring the use of GIS for environmental research, monitoring and management of military lands.</p>
-<p>Since no other software package available back then met all their requirements, they designed and  developed their own. GRASS was born under the name of Fort Hood Information System (FHIS). Meanwhile, other US federal agencies and environmental offices became interested and the more general purpose <b>GRASS was born</b>. </p>
+<p>Since no other software package available back then met all their requirements, they designed and developed their own. GRASS was born under the name of Fort Hood Information System (FHIS). Meanwhile, other US federal agencies and environmental offices became interested, and the more general purpose <b>GRASS was born</b>. </p>
 <p>Several universities adopted GRASS as an important training and research environment and many conducted short-courses for the public, in addition to using GRASS in their own curricula. Indeed, in 1988, GRASS received an award for quality software from the Urban and Regional Information Systems Association (URISA) in <b>1988</b>, only 4 years after the first release.</p>
 </div>
 <div class="col-lg-4 col-sm-12">
@@ -85,7 +85,7 @@ Official GRASS video of the US Army CERL, narrated by William Shatner (<a href="
 <p>
 In February <b>2006</b>, the Open Source Geospatial Foundation (OSGeo) was formed to support and promote worldwide use and collaborative development of Open Source geospatial technologies and data. GRASS is one of its founding projects. Later that year, the GRASS Project Steering Committee was formed which is responsible for the overall management of the project.</p>
 <p>
-On Dec 9, <b>2007</b> GRASS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS <a href="/about/history/web-evolution">website evolution page</a>.<p>
+On December 9, <b>2007</b> GRASS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS <a href="/about/history/web-evolution">website evolution page</a>.<p>
 </div>
 <div class="col-lg-4 col-sm-12">
  <img src="/images/conferences_logos/FOSS4G2004_Mayuri.png"  width="93%" />		   

--- a/content/about/history.md
+++ b/content/about/history.md
@@ -1,10 +1,10 @@
 ---
 title: "History"
-date: 2018-12-29T11:02:05+06:00
+date: 2025-05-16T11:02:05+06:00
 layout: "general"
 ---
 
-## GRASS GIS history
+## GRASS history
 
 <div class="container">
 <div class="timeline mb-5">
@@ -19,16 +19,16 @@ layout: "general"
 <div class="panel-body mb-4">
 <div class="row">
 <div class="col-lg-8 col-sm-12">
-<p>GRASS GIS has been under continuous development since <b>1982</b>, when the U.S. Army Corps of Engineers' Construction Engineering Research Laboratory (USA/CERL)
+<p>GRASS (Geographic Resources Analysis Support System) has been under continuous development since <b>1982</b>, when the U.S. Army Corps of Engineers' Construction Engineering Research Laboratory (USA/CERL)
 started exploring the use of GIS for environmental research, monitoring and management of military lands.</p>
-<p>Since no other software package available back then met all their requirements, they designed and  developed their own. GRASS GIS was born under the name of Fort Hood Information System (FHIS). Meanwhile, other US federal agencies and environmental offices became interested and the more general purpose <b>GRASS was born</b>. </p>
+<p>Since no other software package available back then met all their requirements, they designed and  developed their own. GRASS was born under the name of Fort Hood Information System (FHIS). Meanwhile, other US federal agencies and environmental offices became interested and the more general purpose <b>GRASS was born</b>. </p>
 <p>Several universities adopted GRASS as an important training and research environment and many conducted short-courses for the public, in addition to using GRASS in their own curricula. Indeed, in 1988, GRASS received an award for quality software from the Urban and Regional Information Systems Association (URISA) in <b>1988</b>, only 4 years after the first release.</p>
 </div>
 <div class="col-lg-4 col-sm-12">
 <div style="position: relative; width: 100%; aspect-ratio: 16 / 9;">
   <iframe src="https://av.tib.eu/player/12963" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
 </div>
-Official GRASS GIS video of the US Army CERL, narrated by William Shatner (<a href="https://doi.org/10.5446/12963" target="_blank">DOI</a>)
+Official GRASS video of the US Army CERL, narrated by William Shatner (<a href="https://doi.org/10.5446/12963" target="_blank">DOI</a>)
 <br><br>
 <h4 class="mt-4">Further reading</h4>
 <ul>
@@ -54,15 +54,15 @@ Official GRASS GIS video of the US Army CERL, narrated by William Shatner (<a hr
 <div class="panel-body mb-4">
 <div class="row">
 <div class="col-lg-8 col-sm-12">
-<p>A large number of US federal agencies, universities, and private companies got also involved in the development during the 90's. The core components of GRASS versions 1.0 to 5.0 and the coordination of efforts towards GRASS GIS releases were led by the USA-CERL in Champaign, Illinois. USA-CERL completed its last release of GRASS as version 4.1 in <b>1992</b>, and provided updates and patches to this release through 1995. They also wrote the core components of the GRASS 5.0 floating point version. </p>
+<p>A large number of US federal agencies, universities, and private companies got also involved in the development during the 90's. The core components of GRASS versions 1.0 to 5.0 and the coordination of efforts towards GRASS releases were led by the USA-CERL in Champaign, Illinois. USA-CERL completed its last release of GRASS as version 4.1 in <b>1992</b>, and provided updates and patches to this release through 1995. They also wrote the core components of the GRASS 5.0 floating point version. </p>
 <p>In <b>1997</b>, and after two years of uncertainty, GRASS development was taken over by academia: Baylor University in Texas for a period, and then University of Hannover in Germany; led by Markus Neteler. The <b>GRASS Development Team</b> grew into a multi-national team consisting of developers at numerous locations who manages the source code, releases, and documentation ever since then.</p>
-<p>In October <b>1999</b>, GRASS GIS in its version 5.0 was released for the first time under <a href="/about/history/gnu-release">GNU General Public License (GPL)</a> and in December that year, the source code management moved to the first centralized source code repository (see change to <a href="https://trac.osgeo.org/grass/changeset/9499">CVS</a>. Before that, mainly manual source code management was done.</p>
+<p>In October <b>1999</b>, GRASS in its version 5.0 was released for the first time under <a href="/about/history/gnu-release">GNU General Public License (GPL)</a> and in December that year, the source code management moved to the first centralized source code repository (see change to <a href="https://trac.osgeo.org/grass/changeset/9499">CVS</a>. Before that, mainly manual source code management was done.</p>
 </div>
 <div class="col-lg-4 col-sm-12">
 <img src="/images/gallery/community/1990_shapiro_westervelt_goran.png"  width="93%" />
 <h4 class="mt-4">Further reading</h4>
 <ul>
-<li><a href="/about/history/gnu-release">First GRASS GIS GNU release</a></li>
+<li><a href="/about/history/gnu-release">First GRASS GNU release</a></li>
 </ul>
 </div>
 </div>
@@ -81,11 +81,11 @@ Official GRASS GIS video of the US Army CERL, narrated by William Shatner (<a hr
         <div class="panel-body mb-4">
  <div class="row">
  <div class="col-lg-8 col-sm-12">
- <p>In September <b>2004</b>, the <a href="http://gisws.media.osaka-cu.ac.jp/grass04/">FOSS / GRASS GIS Users Conference</a> was held in Chulalongkorn university, Bangkok, Thailand. This was the first <b>FOSS4G</b> event ever ! </p>
+ <p>In September <b>2004</b>, the <a href="http://gisws.media.osaka-cu.ac.jp/grass04/">FOSS / GRASS Users Conference</a> was held in Chulalongkorn university, Bangkok, Thailand. This was the first <b>FOSS4G</b> event ever ! </p>
 <p>
-In February <b>2006</b>, the Open Source Geospatial Foundation (OSGeo) was formed to support and promote worldwide use and collaborative development of Open Source geospatial technologies and data. GRASS GIS is one of its founding projects. Later that year, the GRASS Project Steering Committee was formed which is responsible for the overall management of the project.</p>
+In February <b>2006</b>, the Open Source Geospatial Foundation (OSGeo) was formed to support and promote worldwide use and collaborative development of Open Source geospatial technologies and data. GRASS is one of its founding projects. Later that year, the GRASS Project Steering Committee was formed which is responsible for the overall management of the project.</p>
 <p>
-On Dec 9, <b>2007</b> GRASS GIS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS GIS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS GIS <a href="/about/history/web-evolution">website evolution page</a>.<p>
+On Dec 9, <b>2007</b> GRASS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS <a href="/about/history/web-evolution">website evolution page</a>.<p>
 </div>
 <div class="col-lg-4 col-sm-12">
  <img src="/images/conferences_logos/FOSS4G2004_Mayuri.png"  width="93%" />		   
@@ -108,10 +108,10 @@ On Dec 9, <b>2007</b> GRASS GIS started to use SVN and Trac bug tracker hosted b
  <div class="row">
  <div class="col-lg-8 col-sm-12">
  <p><b>GRASS turned 30 in 2013</b>! Have a look at this nice commemorative article from ERDC’s CERL and note Jim Westervelt in the picture: <a href="http://www.erdc.usace.army.mil/Media/News-Stories/Article/476565/grass-gis-turns-30-erdcs-cerl-was-there-at-the-start/">GRASS GIS turns 30 – ERDC’s CERL was there at the start</a></p>
-<p>Last but not least, in 2019 GRASS GIS migrated the software development from OSGeo-SVN to <a href="https://github.com/OSGeo/grass">Github</a>. From January 2020, also the bug tracking takes place in GitHub (<a href="https://trac.osgeo.org/grass/wiki/GitMigration">details</a>)</p>
+<p>Last but not least, in 2019 GRASS migrated the software development from OSGeo-SVN to <a href="https://github.com/OSGeo/grass">Github</a>. From January 2020, also the bug tracking takes place in GitHub (<a href="https://trac.osgeo.org/grass/wiki/GitMigration">details</a>)</p>
 <ul id="links" class="version">
  <li>Keynote presentation by Markus Neteler at FOSS4G CEE 2013 in Romania: <a href="https://www.slideshare.net/markusN/scaling-up-globally-30-years-of-foss4g-development-keynote-at-foss4gcee-2013-romania" target=""_blank">Scaling up globally: 30 years of FOSS4G development</a>.</li>
- <li>Presentation by Vaclav Petras at the 30th North Carolina GIS Conference in Raleigh, 2017: <a href="https://ncsu-geoforall-lab.github.io/grass-as-a-platform/ncgis2017.html#/" target="_blank">33 years of GRASS GIS as an innovation platform</a>.</li>
+ <li>Presentation by Vaclav Petras at the 30th North Carolina GIS Conference in Raleigh, 2017: <a href="https://ncsu-geoforall-lab.github.io/grass-as-a-platform/ncgis2017.html#/" target="_blank">33 years of GRASS as an innovation platform</a>.</li>
 </ul>
 </div>
 <div class="col-lg-4 col-sm-12">
@@ -126,7 +126,7 @@ On Dec 9, <b>2007</b> GRASS GIS started to use SVN and Trac bug tracker hosted b
 </div>
 </div>
 
-## More GRASS GIS history
+## More GRASS history
 
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-info-circle"></i> <b>Releases timeline</b> : See the full list of <a href="/about/history/releases">GRASS GIS releases</a> since 1982.


### PR DESCRIPTION
- expand GRASS acronym (at least in one place on the website)
- remove GIS from "GRASS GIS" as per PSC decision