### PR TITLE
Replace grass-web email by other channels

### DIFF
--- a/content/about/credits.md
+++ b/content/about/credits.md
@@ -15,9 +15,9 @@ layout: "credits"
   Ruta Provincial C45 Km 8<br>
   5187 Falda del Cañete<br>
   Córdoba, Argentina<br>
-  <a href="mailto:grass-web@lists.osgeo.org" target="_blank">grass-web@lists.osgeo.org</a>
-<br>
-  <a href="https://grass.osgeo.org" target="_blank">https://grass.osgeo.org</a>
+  <a href="https://grass.osgeo.org" target="_blank">https://grass.osgeo.org</a><br>
+  <a href="https://grass.osgeo.org/support/commercial/" target="_blank">Commercial Support</a><br>
+  <a href="https://grass.osgeo.org/support/community/" target="_blank">Community Support</a>
   </p>
 </div>
 
@@ -30,9 +30,9 @@ layout: "credits"
   Beaverton, Oregon<br>
   United States<br>
   97005-2343<br>
-  <a href="mailto:grass-web@lists.osgeo.org" target="_blank">grass-web@lists.osgeo.org</a>
-<br>
-  <a href="https://grass.osgeo.org" target="_blank">https://grass.osgeo.org</a>
+  <a href="https://grass.osgeo.org" target="_blank">https://grass.osgeo.org</a><br>
+  For support, contact us <a href="https://grass.osgeo.org/support/commercial/" target="_blank">here</a> for commercial services and <a href="https://grass.osgeo.org/support/community/" target="_blank">here</a> for
+  community help.
   </p>
 </div>
 

--- a/content/about/license.md
+++ b/content/about/license.md
@@ -26,7 +26,7 @@ If you are not sure about the differences between public domain
 software, Free Software and proprietary products, have a look 
 at this graphic describing [categories of Free and Non-Free Software](https://www.gnu.org/philosophy/categories.html).
 
-Questions regarding details of this policy can be directed to 
-this <a href="mailto:grass-web@lists.osgeo.org" target="_blank">email address</a>.
+Questions regarding details of this policy can be directed to any of
+the <a href="https://discourse.osgeo.org/c/grass/62" target="_blank">Discourse</a> channels.
 
 See also the [Frequently Asked Questions about the GNU GPL](https://www.gnu.org/licenses/gpl-faq.html).


### PR DESCRIPTION
I tried 2 options on the Credits page (Which one do you prefer?) and put Discourse channels for questions about our license. See screenshots

![image](https://github.com/user-attachments/assets/e49f485c-4559-42b6-97cb-447cbe576805)

![image](https://github.com/user-attachments/assets/53ad502c-c397-4c34-8fa3-734fdb6892e2)

Fixes #536. 