### PR TITLE
Linux download: fix 'The packaging status does not work'

### DIFF
--- a/content/download/linux.en.md
+++ b/content/download/linux.en.md
@@ -10,11 +10,10 @@ layout: "os"
 
 [ [**GRASS {{< grassVersion version="current" type="short">}} (current)**](#GRASS-GIS-current) | [**GRASS {{< grassVersion version="legacy" type="short">}} (legacy)**](#GRASS-GIS-old) | [**GRASS {{< grassVersion version="preview" type="short">}} (preview)**](#GRASS-GIS-devel) ]
 
-The packaging status does not work
-<!-- <i class="fa fa-arrow-right"></i> Install <tt>grass</tt> package on your Linux distribution. Have a look at 
-{{< donateDialog isToggle=true isMarkdown=true >}}[Repology](https://repology.org/project/grass/versions){{< /donateDialog  >}} for an extended
+<i class="fa fa-arrow-right"></i> Install <tt>grass</tt> package on your Linux distribution. Have a look at
+{{< donateDialog isToggle=true isMarkdown=true >}}[Repology](https://repology.org/project/grass-gis/versions){{< /donateDialog  >}} for an extended
 list of GRASS packages or directly check the 
-<a href="https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion={{< grassVersion version="current" >}}&columns=3" class="btn btn-primary">Packaging Status</a>
+<a href="https://repology.org/badge/vertical-allrepos/grass-gis.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion={{< grassVersion version="current" >}}&columns=3" class="btn btn-primary">Packaging Status</a>
 to quickly know which GRASS version is currently available for your distro.
 
 *  {{< donateDialog isToggle=true isMarkdown=true >}}[Arch Linux](https://aur.archlinux.org/packages/grass/){{< /donateDialog  >}}

--- a/content/download/mac.en.md
+++ b/content/download/mac.en.md
@@ -13,10 +13,10 @@ layout: "os"
 <div class="alert rounded-0 alert-default">
 <i class="fa fa-arrow-right"></i> Find <b>GRASS binaries</b> on
  {{< donateDialog isToggle=true >}}  
-     <a href="https://cmbarton.github.io/grass-mac/download/" target="_blank"> GRASS for the Mac </a> 
+     <a href="https://cmbarton.github.io/grass-mac/download/" target="_blank"> GRASS for the Mac </a>
  {{< /donateDialog  >}} 
 or install the latest available version from <a href="https://ports.macports.org/port/grass/" target="_blank">MacPorts</a> 
-<a href="https://repology.org/project/grass/versions" target="_blank"> 
+<a href="https://repology.org/project/grass-gis/versions" target="_blank">
   <img class="inl" src="https://repology.org/badge/version-for-repo/macports/grass-gis.svg" alt="MacPorts package">
 </a>
 (see this brief <a href="https://grasswiki.osgeo.org/wiki/Compiling_on_macOS_using_MacPorts" target="_blank">introduction</a> on using MacPorts).


### PR DESCRIPTION
This PR reverts the 'The packaging status does not work' part by correcting the URLs to https://repology.org/project/grass-gis/ upon hint by @echoix (thanks!).

The repology.org URLs should be with `grass-gis` instead of `grass`.

Now it is back like this:

<img width="1130" height="882" alt="image" src="https://github.com/user-attachments/assets/6c320759-3deb-4906-a9a3-e75d5b4d0c67" />


Fixes https://github.com/OSGeo/grass/issues/5789