### PR TITLE
news: Highlight we are after the summit

### DIFF
--- a/content/news/2025_03_03_GRASS_Developer_Summit_2025.md
+++ b/content/news/2025_03_03_GRASS_Developer_Summit_2025.md
@@ -1,5 +1,5 @@
 ---
-title: "GRASS Developer Summit 2025"
+title: "GRASS Developer Summit 2025 Announcement"
 date: 2025-03-03T10:12:42-05:00
 layout: "news"
 author: Vaclav Petras and the Developer Summit 2025 Organizing Committee

--- a/content/news/2025_05_27_GRASS_Dev_Summit_Report.md
+++ b/content/news/2025_05_27_GRASS_Dev_Summit_Report.md
@@ -1,5 +1,5 @@
 ---
-title: "GRASS Developer Summit 2025"
+title: "GRASS Developer Summit 2025 Report"
 date: 2025-05-26T10:42:00+01:00
 layout: "news"
 author: Vaclav Petras, Veronica Andreo and Caitlin Haedrich

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -53,8 +53,8 @@
                             <div class="carousel-item-container">
                                 <img alt="GRASS team" src="{{.Site.BaseURL}}/images/other/website-dev-summit-2025carousel-image.png">
                                 <div class="carousel-item-overlay">
-                                    <a href="https://grasswiki.osgeo.org/wiki/GRASS_Developer_Summit_Raleigh_2025" target="_blank" class="carousel-link-light">
-                                        Join US
+                                    <a href="{{.Site.BaseURL}}/news/2025_05_27_grass_dev_summit_report/" target="_blank" class="carousel-link-light">
+                                        See what happened at the Developer Summit
                                     </a>
 
                                 </div>


### PR DESCRIPTION
The titles and links for the developer summit look are unclear. The new titles, link, and text show better that we are after the summit and point better to the report news post.

<img width="2235" height="934" alt="Screenshot from 2025-08-19 10-16-27" src="https://github.com/user-attachments/assets/bfaff73a-80ff-43cd-9dec-63b886854180" />
