### PR TITLE
mirror sites: remove deactivated South African mirror

### DIFF
--- a/content/about/mirrors.md
+++ b/content/about/mirrors.md
@@ -13,7 +13,6 @@ layout: "general"
 ## Mirror sites
 
 - [Morocco](https://grass.marwan.ma/) (Moroccan National Research and Education Network, MARWAN)
-- [South Africa](https://grass.mirror.ac.za/) (TENET)
 - [Italy](https://grass.mirror.download.it) (Download.it)
 - [USA](https://mirrors.ibiblio.org/grass/html/) (ibiblio)
 


### PR DESCRIPTION
TENET (South African mirror host) contacted me to announce the deactivation upcoming this month.
This PR removes the entry accordingly.

A big thank-you to TENET for their long term service!