### PR TITLE
Fix: Privacy Policy link on Credits Page (#566)

### DIFF
--- a/content/about/credits.md
+++ b/content/about/credits.md
@@ -39,7 +39,7 @@ This is a community maintained website. The GRASS Development Team and the GRASS
 
 #### Privacy policy
 
-Please read our <a href="https://grass.osgeo.org/about/privacy/">Privacy Policy</a>
+Please read our [privacy policy](/about/privacy/).
 
 #### License
 


### PR DESCRIPTION
# **Fix: Correct Privacy Policy Link on Credits Page (#566)**

The **Privacy Policy** link on the Credits page was pointing to an incorrect URL.

###  Fix

Updated the link to correctly redirect to:
[https://grass.osgeo.org/about/privacy/](https://grass.osgeo.org/about/privacy/)

### Change

```html
<a href="https://grass.osgeo.org/about/privacy/">Privacy Policy</a>
```

