### PR TITLE
Change banner from Gitter to YT and NumFOCUS

### DIFF
--- a/themes/grass/layouts/partials/banner.html
+++ b/themes/grass/layouts/partials/banner.html
@@ -1,5 +1,4 @@
-<div class="gitter-banner"
-          >
-    Feeling chatty? <a href="https://gitter.im/grassgis/community" target="_blank"
-    >Join our Gitter chatroom</a> if you have any question or want to chat about the software!
+<div class="gitter-banner">
+    Follow us on <a href="https://www.youtube.com/@grass-gis" target="_blank">YouTube</a>.
+    Support us through <a href="https://numfocus.org/donate-to-grass" target="_blank">NumFOCUS</a>.
 </div>


### PR DESCRIPTION
In light of the annual report content as well as the fact that it will be published soon, I'm suggesting to change the banner to link to YouTube and NumFOCUS. We previosly discussed (I think at a PSC meeting, so it might be in some minutes) that the Gitter profiled mostly as a special-purpose tool, which we are keeping, but we don't need to necesserily point everyone there. Discourse should get its general use. On the other hand, our YouTube channel could use more subscribers, and visitors to the website might be the right group to target. Financial support was recently changed from Open Collective to NumFOCUS donation link, so that worth promoting just for that reason, but it is also a thing to promote anytime.

The links I picked are something we can keep there for some time without a need to change them any time soon.

I'm also changing the indent in the code. The previous code was splitting the HTML tags.

## Landing page

<img width="1398" height="488" alt="image" src="https://github.com/user-attachments/assets/caf594bd-0c78-4dc7-8f24-67f3fa548630" />

## Content page

<img width="1398" height="488" alt="image" src="https://github.com/user-attachments/assets/0f603503-4afa-4101-851e-5c1d4aae2762" />
