### PR TITLE
website: add GRASS OSGeo incubation graduation milestone

### DIFF
--- a/content/about/history.md
+++ b/content/about/history.md
@@ -85,7 +85,10 @@ Official GRASS video of the US Army CERL, narrated by William Shatner (<a href="
 <p>
 In February <b>2006</b>, the Open Source Geospatial Foundation (OSGeo) was formed to support and promote worldwide use and collaborative development of Open Source geospatial technologies and data. GRASS is one of its founding projects. Later that year, the GRASS Project Steering Committee was formed which is responsible for the overall management of the project.</p>
 <p>
-On December 9, <b>2007</b> GRASS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS <a href="/about/history/web-evolution">website evolution page</a>.<p>
+On December 9, <b>2007</b> GRASS started to use SVN and Trac bug tracker hosted by OSGeo. Other GRASS project infrastructures like the website and mailing lists were (and still are) hosted by OSGeo. Just for fun have a look at the GRASS <a href="/about/history/web-evolution">website evolution page</a>.</p>
+<p>
+On February 8, <b>2008</b>, the OSGeo board approved GRASS’ graduation from the OSGeo incubation process, which it had entered in February 2006.</p>
+
 </div>
 <div class="col-lg-4 col-sm-12">
  <img src="/images/conferences_logos/FOSS4G2004_Mayuri.png"  width="93%" />		   


### PR DESCRIPTION
Adds the missing 2008 OSGeo incubation graduation milestone to the GRASS History page, based on OSGeo incubation records.

Fixes #509.
