### PR TITLE
Add conda to downloads

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -135,21 +135,27 @@ weight = 4
 
 [[Languages.en.menu.main]]
 parent = "Download"
+name = "conda"
+URL = "/download/conda"
+weight = 5
+
+[[Languages.en.menu.main]]
+parent = "Download"
 name = "Docker images"
 URL = "/download/docker"
-weight = 5
+weight = 6
 
 [[Languages.en.menu.main]]
 parent = "Download"
 name = "Addons"
 URL = "/download/addons"
-weight = 6
+weight = 7
 
 [[Languages.en.menu.main]]
 parent = "Download"
 name = "Sample data"
 URL = "/download/data"
-weight = 7
+weight = 8
 
 [[Languages.en.menu.main]]
 weight = 3

--- a/content/download/conda.en.md
+++ b/content/download/conda.en.md
@@ -1,0 +1,83 @@
+---
+title: "conda"
+date: 2026-02-20T10:00:00+00:00
+description: "Install GRASS with conda from conda-forge"
+weight: 5
+layout: "conda"
+---
+
+<i class="fa fa-arrow-right"></i> The `grass` package is available on
+[conda-forge](https://anaconda.org/conda-forge/grass)
+for **Linux** (64-bit) and **macOS** (Intel and Apple Silicon).
+See the
+[conda-forge grass feedstock](https://github.com/conda-forge/grass-feedstock)
+for packaging details.
+
+### Install with conda
+
+Create a new environment and install GRASS:
+
+```bash
+conda create -n grass -c conda-forge grass
+conda activate grass
+```
+
+Or install into an existing environment:
+
+```bash
+conda install -c conda-forge grass
+```
+
+### Install with mamba
+
+For faster dependency resolution, use [mamba](https://mamba.readthedocs.io/):
+
+```bash
+mamba create -n grass -c conda-forge grass
+mamba activate grass
+```
+
+### Environment file
+
+To create a reproducible environment, save the following as `environment.yml`:
+
+```yaml
+name: grass
+channels:
+  - conda-forge
+dependencies:
+  - grass
+```
+
+Then create the environment with:
+
+```bash
+conda env create -f environment.yml
+conda activate grass
+```
+
+### Usage
+
+#### Python
+
+To use GRASS in Python scripts, add the GRASS Python package path
+to `sys.path`:
+
+```python
+import subprocess
+import sys
+
+result = subprocess.run(["grass", "--config", "python_path"],
+                        check=True, text=True, capture_output=True)
+sys.path.append(result.stdout.strip())
+
+import grass.script as gs
+```
+
+#### Command line
+
+After activating the conda environment, start GRASS from the command line:
+
+```bash
+grass
+```

--- a/themes/grass/layouts/download/conda.html
+++ b/themes/grass/layouts/download/conda.html
@@ -1,0 +1,35 @@
+{{ partial "head.html" . }}
+
+{{ "<!-- navigation -->" | safeHTML }}
+<header class="shadow-bottom position-relative">
+  <div class="fixed-top">
+    {{ partial "banner.html" . }}
+    <div class="bg-primary">
+      <div class="container bg-primary">
+        {{ partial "navigation.html" . }}
+      </div>
+    </div>
+  </div>
+</header>
+{{ "<!-- /navigation -->" | safeHTML }}
+
+
+
+<!-- details page -->
+<section class="single section bg-gray pb-0 mt-5">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="p-5 bg-white">
+          <img src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" class="pull-right">
+          <h2 class="page-title">GRASS for {{ .Title }}</h2>
+          {{ .Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- /details page -->
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
This creates a new page under download for conda. It offers installation commands for conda and mamba as well as environment setup. Additionally, it shows usage in command like (should work out of the box) and in Python (requires additional setup). While this is strictly not download, showing what is the expected result is useful, especially given that the current situation is not ideal for Python. In the menu, it is ordered after the three operating systems, but before Docker.

<img width="1323" height="789" alt="image" src="https://github.com/user-attachments/assets/6933abe2-143d-451e-8fa1-dbc640e4d5e2" />
