### PR TITLE
hugo-config: Added site params to fix RSS feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,10 @@ siteName = "GRASS"
 description = "GRASS is a powerful open-source geospatial processing engine that supports advanced modeling, time series analysis, and spatial data management."
 keywords = "python, science, data science, machine learning, jupyter, vector, geospatial, parallel computing, gis, image processing, raster, spatial, open science, remote sensing, arrays, earth observation, geospatial analysis, timeseries analysis, open source, GRASS, FOSS4G, free open source GIS, mapping, mapping software, cartography, GIS data, open source 3D, geographic information system, free software, libre software, topology, visualization, hydrology, archaeology, 3D GIS"
 
+[params.author]
+name = "GRASS GIS Development Team"
+email = "grass-dev@lists.osgeo.org"
+
 [sitemap]
 changefreq = "monthly"
 filename = "sitemap_hugo.xml"

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ description = "GRASS is a powerful open-source geospatial processing engine that
 keywords = "python, science, data science, machine learning, jupyter, vector, geospatial, parallel computing, gis, image processing, raster, spatial, open science, remote sensing, arrays, earth observation, geospatial analysis, timeseries analysis, open source, GRASS, FOSS4G, free open source GIS, mapping, mapping software, cartography, GIS data, open source 3D, geographic information system, free software, libre software, topology, visualization, hydrology, archaeology, 3D GIS"
 
 [params.author]
-name = "GRASS GIS Development Team"
+name = "GRASS Development Team"
 email = "grass-dev@lists.osgeo.org"
 
 [sitemap]

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ keywords = "python, science, data science, machine learning, jupyter, vector, ge
 
 [params.author]
 name = "GRASS Development Team"
-email = "grass-dev@lists.osgeo.org"
+email = "https://discourse.osgeo.org/c/grass/developer/61"
 
 [sitemap]
 changefreq = "monthly"

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ keywords = "python, science, data science, machine learning, jupyter, vector, ge
 
 [params.author]
 name = "GRASS Development Team"
-email = "https://discourse.osgeo.org/c/grass/developer/61"
+contact = "https://discourse.osgeo.org/c/grass/developer/61"
 
 [sitemap]
 changefreq = "monthly"

--- a/themes/grass/layouts/_default/rss.xml
+++ b/themes/grass/layouts/_default/rss.xml
@@ -30,7 +30,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.contact }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>

--- a/themes/grass/layouts/_default/rss.xml
+++ b/themes/grass/layouts/_default/rss.xml
@@ -18,8 +18,8 @@
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -30,7 +30,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>

--- a/themes/grass/layouts/_default/rss.xml
+++ b/themes/grass/layouts/_default/rss.xml
@@ -18,7 +18,7 @@
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.contact }}
     <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}

--- a/themes/grass/layouts/_default/rss.xml
+++ b/themes/grass/layouts/_default/rss.xml
@@ -20,7 +20,7 @@
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.contact }}
     <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <copyright>{{ replace . "{year}" (now.Format "2006") | safeHTML }}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
 	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}


### PR DESCRIPTION
 This pull request open for this issue #604  .


Results in both version in hugo 0.113 and hugo 0.157 in below


**hugo v.0113

tart building sites … 
hugo v0.113.0-085c1b3d614e23d218ebf9daad909deaa2390c9a+extended darwin/arm64 BuildDate=2023-06-05T15:04:51Z VendorInfo=gohugoio

                   |  EN   
-------------------+-------
  Pages            |  241  
  Paginator pages  |    0  
  Non-page files   |   10  
  Static files     | 1254  
  Processed images |   66  
  Aliases          |    0  
  Sitemaps         |    1  
  Cleaned          |    0  

Built in 733 ms
Watching for changes in /Users/tangel/Works/grass-website/{archetypes,content,data,static,themes}
Watching for config changes in /Users/tangel/Works/grass-website/config.toml
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop

**hugo 0.157

Start building sites … 
hugo v0.113.0-085c1b3d614e23d218ebf9daad909deaa2390c9a+extended darwin/arm64 BuildDate=2023-06-05T15:04:51Z VendorInfo=gohugoio

                   |  EN   
-------------------+-------
  Pages            |  241  
  Paginator pages  |    0  
  Non-page files   |   10  
  Static files     | 1254  
  Processed images |   66  
  Aliases          |    0  
  Sitemaps         |    1  
  Cleaned          |    0  

Built in 924 ms
Watching for changes in /Users/tangel/Works/grass-website/{archetypes,content,data,static,themes}
Watching for config changes in /Users/tangel/Works/grass-website/config.toml
Environment: "development"
Serving pages from memory
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop