### PR TITLE
hot-fix: hamburger dropdown, download buttons, download icons, all news

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  hugo-dev:
+    image: hugomods/hugo:0.113.0
+    environment:
+      - HUGO_ENVIRONMENT=development
+      - HUGO_ENV=development
+    working_dir: /src
+    ports:
+      - "1313:1313"
+    volumes:
+      - ./:/src:delegated
+      - hugo_cache:/tmp/hugo_cache
+    command: >-
+      sh -c "apk add --no-cache nodejs npm curl bash
+      && hugo serve --watch --bind 0.0.0.0 --port 1313"
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+
+volumes:
+  hugo_cache:
+    driver: local
+

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -1608,9 +1608,16 @@ code {
     z-index:1;
 }
 .mt-95 {
-    /* This equals the fixed hight of the gitter banner and the nav bar
+    /* This equals the fixed height of the gitter banner and the nav bar
      96.8px when the base font size of the document is (16px) */
     margin-top: 6.05rem;
+}
+@media (max-width: 991px) {
+    /* On mobile the navbar collapses (no nav-link padding), shrinking the
+       fixed header to ~75px (banner ~29px + brand ~46px) */
+    .mt-95 {
+        margin-top: 4.7rem;
+    }
 }
 
 .carousel-item-container {

--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -1577,6 +1577,14 @@ code {
    color: var(--gs-primary-color);
 }
 
+/* Rotate collapse chevron based on Bootstrap's aria-expanded attribute */
+[data-toggle="collapse"] .fa-chevron-right {
+  transition: transform 0.2s ease;
+}
+[data-toggle="collapse"][aria-expanded="true"] .fa-chevron-right {
+  transform: rotate(90deg);
+}
+
 .grassthm{
     border:1px solid #dee2e6;
     background-color: var(--gs-primary-color);

--- a/themes/grass/assets/js/script.js
+++ b/themes/grass/assets/js/script.js
@@ -9,6 +9,17 @@
     };
     $(".navbar-brand span").lastWord();
 
+    // Dynamically match hero section offset to actual fixed header height.
+    // No ready() wrapper needed — scripts are loaded at end of <body>.
+    function adjustHeroOffset() {
+        var headerHeight = $('.fixed-top').outerHeight(true);
+        if (headerHeight) {
+            $('.mt-95').css('margin-top', headerHeight + 'px');
+        }
+    }
+    adjustHeroOffset();
+    $(window).on('resize', adjustHeroOffset);
+
 
     $( 'a' ).each(function() {
   if( location.hostname === this.hostname || !this.hostname.length ) {

--- a/themes/grass/layouts/download/data.html
+++ b/themes/grass/layouts/download/data.html
@@ -20,7 +20,7 @@
     <div class="row">
       <div class="col-lg-12">
       <div class="p-5 bg-white">
-	<img src="{{.Site.BaseURL}}/images/logos/grass-SampleData.jpg" class="pull-right">
+	<img src="{{.Site.BaseURL}}/images/logos/historical_logos/grass-SampleData.jpg" class="pull-right">
 	<h2 class="page-title">GRASS sample data</h2>
 	{{ .Content }}
         </div>

--- a/themes/grass/layouts/download/data.html
+++ b/themes/grass/layouts/download/data.html
@@ -20,7 +20,7 @@
     <div class="row">
       <div class="col-lg-12">
       <div class="p-5 bg-white">
-	<img src="{{.Site.BaseURL}}/images/logos/historical_logos/grass-SampleData.jpg" class="pull-right">
+	<img src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" alt="GRASS logo" class="pull-right">
 	<h2 class="page-title">GRASS sample data</h2>
 	{{ .Content }}
         </div>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -43,7 +43,15 @@
           {{ if not .Params.categories }}
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><img src="{{.Site.BaseURL}}/images/logos/grass-{{.Title}}.jpg" width="110"></div>
+              <div class="col-4 text-center">
+                {{ $imgPath := printf "static/images/logos/historical_logos/grass-%s.jpg" .Title }}
+                {{ if os.FileExists $imgPath }}
+                <img src="{{.Site.BaseURL}}images/logos/historical_logos/grass-{{.Title}}.jpg" width="110" class="pull-right">
+                {{ else }}
+                <img src="{{.Site.BaseURL}}images/logos/grass-logo/grass-green.svg" width="110"
+                  class="pull-right">
+                {{ end }}
+              </div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS for {{ .Title }}</h3>
                 <p>{{ .Description }}</p>
@@ -66,7 +74,7 @@
 
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}/images/logos/grass-SampleData.jpg"></div>
+              <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}images/logos/historical_logos/grass-SampleData.jpg"></div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS sample data</h3>
                 <p>Download ready-to-use GRASS sample datasets</p>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -44,13 +44,7 @@
           <div class="section bg-white mb-4">
             <div class="row nm">
               <div class="col-4 text-center">
-                {{ $imgPath := printf "static/images/logos/historical_logos/grass-%s.jpg" .Title }}
-                {{ if os.FileExists $imgPath }}
-                <img src="{{.Site.BaseURL}}images/logos/historical_logos/grass-{{.Title}}.jpg" width="110" class="pull-right">
-                {{ else }}
-                <img src="{{.Site.BaseURL}}images/logos/grass-logo/grass-green.svg" width="110"
-                  class="pull-right">
-                {{ end }}
+                <img src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" width="110" class="pull-right">
               </div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS for {{ .Title }}</h3>
@@ -63,7 +57,7 @@
           {{ end }}
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grass-logo/grass-green.svg" class="grasslogo"></object></div>
+              <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" class="grasslogo"></object></div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS Addons</h3>
                 <p>Download user contributed GRASS extensions</p>
@@ -74,7 +68,7 @@
 
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}images/logos/historical_logos/grass-SampleData.jpg"></div>
+              <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png"></div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS sample data</h3>
                 <p>Download ready-to-use GRASS sample datasets</p>

--- a/themes/grass/layouts/download/list.html
+++ b/themes/grass/layouts/download/list.html
@@ -27,7 +27,7 @@
       <div class="section bg-white mb-4">
         <div class="row nm">
           <div class="col-4 text-center">
-            <object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grass-logo/grass-green.svg" class="grasslogo"></object>
+            <img alt="GRASS logo" src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" class="pull-right">
           </div>
           <div class="col-8">
             <h3 class="mt-20">GRASS source code</h3>
@@ -44,7 +44,7 @@
           <div class="section bg-white mb-4">
             <div class="row nm">
               <div class="col-4 text-center">
-                <img src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" width="110" class="pull-right">
+                <img alt="GRASS logo" src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" class="pull-right">
               </div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS for {{ .Title }}</h3>
@@ -57,7 +57,9 @@
           {{ end }}
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><object type="image/svg+xml" data="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" class="grasslogo"></object></div>
+              <div class="col-4 text-center">
+                <img alt="GRASS logo" src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" class="pull-right">
+              </div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS Addons</h3>
                 <p>Download user contributed GRASS extensions</p>
@@ -68,7 +70,8 @@
 
           <div class="section bg-white mb-4">
             <div class="row nm">
-              <div class="col-4 text-center"><img alt="GRASS GIS" src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png"></div>
+              <div class="col-4 text-center">
+                <img alt="GRASS logo" src="{{.Site.BaseURL}}/images/logos/grass-logo-simple/grass-green-no-text.svg" width="110" class="pull-right"></div>
               <div class="col-8">
                 <h3 class="mt-2 mb-2">GRASS sample data</h3>
                 <p>Download ready-to-use GRASS sample datasets</p>

--- a/themes/grass/layouts/download/os.html
+++ b/themes/grass/layouts/download/os.html
@@ -21,7 +21,12 @@
     <div class="row">
       <div class="col-lg-12">
       <div class="p-5 bg-white">
-	<img src="{{.Site.BaseURL}}/images/logos/grass-{{.Title}}.jpg" width="110" class="pull-right">
+	{{ $imgPath := printf "static/images/logos/historical_logos/grass-%s.jpg" .Title }}
+	{{ if os.FileExists $imgPath }}
+	<img src="{{.Site.BaseURL}}images/logos/historical_logos/grass-{{.Title}}.jpg" width="110" class="pull-right">
+	{{ else }}
+	<img src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" width="110" class="pull-right">
+	{{ end }}
 	<h2 class="page-title">GRASS for {{ .Title }}</h2>
 	 {{ .Content }}
         </div>

--- a/themes/grass/layouts/download/os.html
+++ b/themes/grass/layouts/download/os.html
@@ -20,15 +20,10 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-12">
-      <div class="p-5 bg-white">
-	{{ $imgPath := printf "static/images/logos/historical_logos/grass-%s.jpg" .Title }}
-	{{ if os.FileExists $imgPath }}
-	<img src="{{.Site.BaseURL}}images/logos/historical_logos/grass-{{.Title}}.jpg" width="110" class="pull-right">
-	{{ else }}
-	<img src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" width="110" class="pull-right">
-	{{ end }}
-	<h2 class="page-title">GRASS for {{ .Title }}</h2>
-	 {{ .Content }}
+        <div class="p-5 bg-white">
+	        <img src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-logo-green-simple@1x.png" width="110" class="pull-right">
+	        <h2 class="page-title">GRASS for {{ .Title }}</h2>
+	        {{ .Content }}
         </div>
       </div>
     </div>

--- a/themes/grass/layouts/index.html
+++ b/themes/grass/layouts/index.html
@@ -9,7 +9,7 @@
         </div>
       </div>
     </div>
-    <section class="pt-3 mt-95">
+    <section class="pt-1 pt-lg-3 mt-95">
         <div class="container">
         <div class="row">
             <div class="col-lg-8 text-center mx-auto">

--- a/themes/grass/layouts/news/allnews.html
+++ b/themes/grass/layouts/news/allnews.html
@@ -58,16 +58,12 @@
 
               <!-- YEAR TITLE WITH ICON -->
               <a class="d-block h3 text-dark text-decoration-none"
-                 data-bs-toggle="collapse"
+                 data-toggle="collapse"
                  href="#{{ $collapseID }}"
+                 role="button"
+                 aria-controls="{{ $collapseID }}"
                  aria-expanded="{{ if eq $year $currentYear }}true{{ else }}false{{ end }}">
-
-                {{ if eq $year $currentYear }}
-                  <i class="fa-solid fa-chevron-up me-2"></i>{{ $year }}
-                {{ else }}
-                  <i class="fa-solid fa-chevron-down me-2"></i>{{ $year }}
-                {{ end }}
-
+                 <i class="fa-solid fa-chevron-right me-2 p-2"></i>{{ $year }}
               </a>
 
               <!-- POSTS -->

--- a/themes/grass/layouts/partials/footer.html
+++ b/themes/grass/layouts/partials/footer.html
@@ -87,8 +87,10 @@
   </div>
 </footer>
 
-<!-- Load Bootstrap 5 bundle (includes Popper). Replace with a local Bootstrap 5 bundle if you prefer -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="" crossorigin="anonymous"></script>
+
+<!-- Bootstrap JS (requires jQuery loaded in head, then Popper for dropdowns) -->
+<script src="{{ .Site.BaseURL }}plugins/popper/popper.min.js"></script>
+<script src="{{ .Site.BaseURL }}plugins/bootstrap/bootstrap.min.js"></script>
 
 <!-- highlight & gallery -->
 <script src="{{ .Site.BaseURL }}plugins/highlight/highlight.min.js"></script>

--- a/themes/grass/layouts/partials/navigation.html
+++ b/themes/grass/layouts/partials/navigation.html
@@ -1,9 +1,9 @@
-<nav class="navbar navbar-expand-lg navbar-light">
+<nav class="navbar navbar-expand-lg navbar-dark">
     <a class="navbar-brand" href="{{.Site.BaseURL}}">
         <img class="grass-icon" alt="GRASS Logo" src="{{.Site.BaseURL}}images/logos/grass-logo-simple/grass-white-no-text.svg">
         <span class="grass text-white">{{.Site.Params.logo}}</span>
     </a>
-    <button 
+    <button
         aria-controls="navigation"
         aria-expanded="false"
         aria-label="Toggle navigation"
@@ -15,28 +15,31 @@
     </button>
     <div class="collapse navbar-collapse text-center" id="navigation">
         <ul class="navbar-nav ml-auto">
-            <li style="list-style: none">{{ range .Site.Menus.main}}{{if .HasChildren}} </li>
+            {{ range .Site.Menus.main }}
+            {{- if .HasChildren }}
             <li class="nav-item dropdown">
-                <a 
+                <a
                     aria-expanded="false"
                     aria-haspopup="true"
                     class="nav-link dropdown-toggle text-light"
                     data-toggle="dropdown"
                     href="{{.URL}}"
+                    id="dropdown-{{ .Name | urlize }}"
                     role="button">{{ .Name }}
                 </a>
-                <div class="dropdown-menu">
+                <div class="dropdown-menu" aria-labelledby="dropdown-{{ .Name | urlize }}">
                     {{ range .Children }}
                     <a class="dropdown-item" href="{{.URL}}">{{.Name}}</a>
-                    {{end}}
+                    {{ end }}
                 </div>
             </li>
-            <li style="list-style: none">{{ else }}</li>
-            <li class="nav-item"><a class="nav-link text-dark" href="{{.URL}}">{{ .Name }}</a></li>
-            <li style="list-style: none">{{ end }}{{ end }}</li>
+            {{- else }}
+            <li class="nav-item"><a class="nav-link text-light" href="{{.URL}}">{{ .Name }}</a></li>
+            {{- end }}
+            {{ end }}
         </ul>
 
-        <form class="search-form" id="search-form" onsubmit="searchContent(event)"> 
+        <form class="search-form" id="search-form" onsubmit="searchContent(event)">
             <input id="search-input" class="search-input" type="search" name="searchString">
             <label for="search-input" class="search-icon" aria-label="Search">
                 <i class="fa fa-search" aria-hidden="true"></i>
@@ -49,7 +52,7 @@
 
                 const searchString = encodeURI(`${event.target.searchString.value} site:grass.osgeo.org`);
                 const searchURL = "https://duckduckgo.com?q=" + searchString;
-                
+
                 window.open(searchURL)
             }
         </script>


### PR DESCRIPTION
## Fixes

* Dropdown hamburger button not opening (#573) 
* Dropdown hamburger color (it's now white)
* Brand download buttons (#581) 
* Incorrect path to download page logos (#602)  
* the white gap between navbar and banner on mobile.
* News feed collapse functionally (#511 , #575 ) 

The root issue was caused when we introduced Bootstrap 5 without removing past bootstrap versions and accounting for breaking changes in the bootstrap API.

## Main Issue

In this PR I removed Bootstrap 5 and fixed everything to work with Bootstrap 4.1.3 (the current version in our static plugins directory)

## Testing

I've also included `docker-compose.yml` so you can test the changes locally how they will be rendered on the server. 

To use install docker and then run. 

```
docker compose -f docker-compose.yml up
```

The site will be available at [http://localhost:1313/](http://localhost:1313/).

## Moving Forward

This should resolve most of the major issues with the website at the moment and will give us more time to address PR #599 and issue #600 .

I have 3 main goals I'm suggesting we accomplish.

1. Modernize the websites dependency management to improve consistency between development environments and production. (#552 , #599)
2. Update our dependencies to the latest versions
    * We already introduced renovate which will help  (#591)
3. Switch from css to dart-scss using hugo-extended  (#599)

The biggest challenges are **migrating to Bootstrap 5** (#600) and then we should **migrate from Hugo v0.113.0 to  v0.157.0**. Both of these migrations need planning (Bootstrap issue #600)  as they will break parts of the site, but in my opinion it is worth the effort to use the latest features.