### PR TITLE
Use Fira Mono or monospace for code, not sans

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -8,7 +8,7 @@
   --gs-grass-font--medium: 'Fira Sans Medium', sans-serif;
   --gs-grass-font--bold: 'Fira Sans Bold', sans-serif;
   --gs-grass-font--light: 'Fira Sans ExtraLight', sans-serif;
-  --gs-grass-font--mono: 'Fira Sans Mono', sans-serif;
+  --gs-grass-font--mono: 'Fira Mono', monospace;
 
   /*  Main Colors 
   ------------------------------------------------------------------------------*/
@@ -607,6 +607,7 @@ table img {
 }
 pre {
   background: transparent;
+  font-family: var(--gs-grass-font--mono);
 }
 .overlay {
   position: relative;


### PR DESCRIPTION
Fira Sans Mono is not a font name as far as I can tell. The font name is Fira Mono.

Fallback for code should be monospace, not sans-serif, so using that.

We don't ship it or link Fira Mono at this point, but I'm fixing the CSS now as a hot fix and leaving the font addition for later.

I'm setting explicit font for pre so that if pre appears without code and Fira Mono is available, we get consistent font with code.
