### PR TITLE
style: Offset anchor jumps so headings are not hidden by the top bar

### DIFF
--- a/themes/grass/assets/css/style.css
+++ b/themes/grass/assets/css/style.css
@@ -1628,6 +1628,17 @@ code {
     }
 }
 
+/* Offset anchor jumps so headings clear the fixed header (same stack
+   measured by .mt-95 above) and leave a small gap below the bar. */
+html {
+    scroll-padding-top: 6.25rem;
+}
+@media (max-width: 991px) {
+    html {
+        scroll-padding-top: 5rem;
+    }
+}
+
 .carousel-item-container {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Without scroll-padding-top, anchor links to headings landed under the .fixed-top banner+navbar and the heading was hidden. Set it on <html>, sized to match the existing .mt-95 measurement, with a small gap so the heading isn't flush against the bar. Add a mobile override for the collapsed navbar.

The numbers are duplicative with .mt-95, but co-locating them in the file is the lightest fix. The issue is visible online. I tested locally.

## To reproduce

* https://grass.osgeo.org/download/linux/ (start here and click a version link)
* https://grass.osgeo.org/download/linux/#GRASS-GIS-current (example link)

## Before (online and locally)

<img width="945" height="455" alt="image" src="https://github.com/user-attachments/assets/848eca2b-f89d-49b7-acd3-abb5eeaa1080" />

## After (locally)

<img width="945" height="455" alt="image" src="https://github.com/user-attachments/assets/7590574d-5cbe-4ba1-8099-64abf418a785" />

