### PR TITLE
Focus Windows download page on OSGeo4W

### DIFF
--- a/content/download/windows.en.md
+++ b/content/download/windows.en.md
@@ -1,71 +1,64 @@
 ---
 title: "Windows"
-date: 2025-05-21T11:02:05+02:00
+date: 2026-05-08T11:02:05+02:00
 description: "Download GRASS installers for Windows"
 weight: 2
 layout: "os"
 ---
 
-
-#### Quick links
-
-[ [**Standalone installers**](#standalone-installers) | [**OSGeo4W**](#OSGeo4W) ]
+[ [**GRASS {{< grassVersion version="current" type="short">}} (current)**](#current) | [**GRASS {{< grassVersion version="preview" type="short">}} (preview)**](#preview) | [**GRASS {{< grassVersion version="legacy" type="short">}} (legacy)**](#legacy) | [**OSGeo4W**](#OSGeo4W) ]
 
 <div class="alert rounded-0 alert-default">
-<i class="fa fa-arrow-right"></i> Install GRASS on Windows using a standalone installer or OSGeo4W. </div>
+<i class="fa fa-arrow-right"></i> Install GRASS on Windows with the <a href="#OSGeo4W">OSGeo4W</a> installer. Windows <a href="/download/conda/">conda</a> packages are coming soon.
+</div>
 
 <hr>
 
 
-### <span id="standalone-installers"> Standalone installers </span>
-
-Standalone installer: install GRASS with the required support packages.
-
-#### <span id="GRASS-GIS-current"> GRASS {{< grassVersion version="current" >}} (current)</span>
+### <span id="current"> GRASS {{< grassVersion version="current" >}} (current)</span>
 
 <div class="alert rounded-0 alert-success">
-<i class="fa fa-info-circle"></i> <u>New stable release</u>, see the <a href="https://github.com/OSGeo/grass/releases/tag/{{< currentVersion.inline  >}}{{- .Site.Data.grass.current_version -}}{{</currentVersion.inline >}}">release announcement</a> for more information.</div>
+<i class="fa fa-info-circle"></i> <em>Current stable release</em>, see the <a href="https://github.com/OSGeo/grass/releases/tag/{{< currentVersion.inline  >}}{{- .Site.Data.grass.current_version -}}{{</currentVersion.inline >}}">release announcement</a> for more information.</div>
 
- 
-*  {{< donateDialog isToggle=true >}}  
-<a href="/grass{{< currentVersionNoDots.inline  >}}{{- .Site.Data.grass.current_version_nodots -}}{{</currentVersionNoDots.inline >}}/binary/mswindows/native/WinGRASS-{{< currentVersion.inline  />}}-1-Setup.exe" target="blank">
-<i class="fa fa-download"></i> Download 64bit 
+*  {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="_blank" rel="noopener">
+<i class="fa fa-download"></i> OSGeo4W installer
 </a>
-{{< /donateDialog  >}} 
- 
-
+{{< /donateDialog  >}} &mdash; select the <b>grass</b> package (see <a href="#OSGeo4W">OSGeo4W</a> below)
+*  [conda](/download/conda/) &mdash; Windows packages coming soon
 
 <hr>
 
-#### <span id="GRASS-GIS-old"> GRASS {{< grassVersion version="legacy" >}} (legacy)</span>
-
-<div class="alert rounded-0 alert-warning">
-<i class="fa fa-info-circle"></i> <u>Old stable release</u>, see <a href="https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures{{< legacyVersionNoDots.inline  >}}{{- .Site.Data.grass.legacy_version_nodots -}}{{</legacyVersionNoDots.inline >}}">GRASS {{< grassVersion version="legacy" type="short">}} new features</a> and <a href="https://github.com/OSGeo/grass/releases/tag/{{< legacyVersion.inline  >}}{{- .Site.Data.grass.legacy_version -}}{{</legacyVersion.inline >}}">GRASS {{< grassVersion version="legacy" >}} announcement</a> for more information.
-</div>
-
-*  {{< donateDialog isToggle=true >}}  
-<a href="/grass{{< legacyVersionNoDots.inline  />}}/binary/mswindows/native/x86_64/WinGRASS-{{< legacyVersion.inline  />}}-3-Setup-x86_64.exe" target="blank">
-<i class="fa fa-download"></i> Download 64bit
-</a>
-{{< /donateDialog  >}} 
-
-<!--
-*  [<i class="fa fa-download"></i> Download 32bit](/grass78/binary/mswindows/native/x86/WinGRASS-7.8.6-3-Setup-x86_64.exe)
--->
-
-<hr>
-
-#### <span id="GRASS-GIS-devel"> GRASS {{< grassVersion version="preview" >}} (preview)</span>
+### <span id="preview"> GRASS {{< grassVersion version="preview" >}} (preview)</span>
 
 <div class="alert rounded-0 alert-info">
-<i class="fa fa-info-circle"></i> Active <u>development</u> and <u>experimental</u> <b>GRASS</b> version.
+<i class="fa fa-info-circle"></i> Active <em>development</em> and <em>experimental</em> <b>GRASS</b> version.
 </div>
 
-*  {{< donateDialog isToggle=true >}}  
-<a href="https://wingrass.fsv.cvut.cz/grass{{< previewVersionNoDots.inline  >}}{{- .Site.Data.grass.preview_version_nodots -}}{{</previewVersionNoDots.inline >}}/" target="blank">
-<i class="fa fa-download"></i> Download 64bit
+*  {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="_blank" rel="noopener">
+<i class="fa fa-download"></i> OSGeo4W installer
+</a>
+{{< /donateDialog  >}} &mdash; select the <b>grass-daily</b> package (see <a href="#OSGeo4W">OSGeo4W</a> below)
+
+<hr>
+
+### <span id="legacy"> GRASS {{< grassVersion version="legacy" >}} (legacy)</span>
+
+<div class="alert rounded-0 alert-warning">
+<i class="fa fa-info-circle"></i> <em>Old stable release</em>, see the <a href="https://github.com/OSGeo/grass/releases/tag/{{< legacyVersion.inline  >}}{{- .Site.Data.grass.legacy_version -}}{{</legacyVersion.inline >}}">release announcement</a> for more information.
+</div>
+
+*  {{< donateDialog isToggle=true >}}
+<a href="https://grass.osgeo.org/grass84/binary/mswindows/native/WinGRASS-8.4.2-1-Setup.exe" target="_blank" rel="noopener">
+<i class="fa fa-download"></i> Standalone installer (64-bit)
 </a>
 {{< /donateDialog  >}}
+*  {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="_blank" rel="noopener">
+<i class="fa fa-download"></i> OSGeo4W installer
+</a>
+{{< /donateDialog  >}} &mdash; see <a href="#OSGeo4W">OSGeo4W</a> below
 
 <hr>
 
@@ -74,26 +67,24 @@ Standalone installer: install GRASS with the required support packages.
 
 OSGeo4W is an installer for a broad set of open source geospatial software packages including GRASS as well as many other packages (QGIS, GDAL/OGR, and more).
 
-*   {{< donateDialog isToggle=true >}}  
-<a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="blank">
+*   {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="_blank" rel="noopener">
 <i class="fa fa-download"></i> Download OSGeo4W v2
 </a>
 {{< /donateDialog  >}}
 
 
-**NOTE FOR EXISTING USERS**: OSGeo4W v2 is now the regular repository. OSGeo4W v2 does not include a 32-bit version. If you need 32-bit support, use the version 1 download (See below). 
-
-**CAUTION**: Upgrades of old (v1) setups using the new repository are not supported. You need to do a fresh install or use a different install directory.
+OSGeo4W v2 is the standard repository and does not include a 32-bit version. The legacy v1 installer below is only needed for 32-bit systems. Upgrading an existing v1 installation by pointing it at the v2 repository is not supported &mdash; do a fresh install or use a different install directory.
 
 Legacy download (OSGeo4W v1)
 
-*  {{< donateDialog isToggle=true >}}  
-<a href="https://download.osgeo.org/osgeo4w/v1/osgeo4w-setup-x86_64-v1.exe" target="blank">
+*  {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v1/osgeo4w-setup-x86_64-v1.exe" target="_blank" rel="noopener">
 <i class="fa fa-download"></i> Download OSGeo4W 64bit version 1
 </a>
 {{< /donateDialog  >}}
-*  {{< donateDialog isToggle=true >}}  
-<a href="https://download.osgeo.org/osgeo4w/v1/osgeo4w-setup-x86-v1.exe" target="blank">
+*  {{< donateDialog isToggle=true >}}
+<a href="https://download.osgeo.org/osgeo4w/v1/osgeo4w-setup-x86-v1.exe" target="_blank" rel="noopener">
 <i class="fa fa-download"></i> Download OSGeo4W 32bit version 1
 </a>
 {{< /donateDialog  >}}
@@ -119,5 +110,5 @@ osgeo4w-setup.exe -q -k -P grass -s https://download.osgeo.org/osgeo4w/v2/x86_64
 In order to have GRASS support (also in QGIS-Processing) you need to install the "qgis*-grass-plugin" packages.
 
 
- {{< donateDialog >}}  
- {{< /donateDialog >}}  
+ {{< donateDialog >}}
+ {{< /donateDialog >}}


### PR DESCRIPTION
Primarily point to OSGeo4W, point to conda too. Keep standalone installer for legacy. Use mixed structure by current, preview (2nd), legacy (3rd), and OSGeo4W in detail.

<img width="997" height="1801" alt="image" src="https://github.com/user-attachments/assets/8d873f81-eff6-4e7a-923e-25a897656223" />
