### PR TITLE
Rename to GRASS in menu, learn, others

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -115,19 +115,19 @@ url = "/download"
 
 [[Languages.en.menu.main]]
 parent = "Download"
-name = "GRASS GIS source code"
+name = "GRASS source code"
 URL = "https://github.com/OSGeo/grass/tags"
 weight = 1
 
 [[Languages.en.menu.main]]
 parent = "Download"
-name = "GRASS GIS for Linux"
+name = "GRASS for Linux"
 URL = "/download/linux"
 weight = 2
 
 [[Languages.en.menu.main]]
 parent = "Download"
-name = "GRASS GIS for Windows"
+name = "GRASS for Windows"
 URL = "/download/windows"
 weight = 3
 

--- a/themes/grass/layouts/download/tabs.html
+++ b/themes/grass/layouts/download/tabs.html
@@ -78,14 +78,14 @@
                     <div class="row mb-5 text-primary">
                       <div class="col-12">
                         <h4>OSGeo4W</h4>
-                        <p>OSGeo4W is an installer for a broad set of open source geospatial software packages including GRASS GIS as well as many other packages (QGIS, GDAL/OGR, and more).</p>
+                        <p>OSGeo4W is an installer for a broad set of open source geospatial software packages including GRASS as well as many other packages (QGIS, GDAL/OGR, and more).</p>
                         <a href="https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" target="_blank"><i class="fa-solid fa-download"></i> Download OSGeo4W v2</a>
                       </div>
                     </div>
                     <div class="row mb-5 text-primary">
                       <div class="col-12">
                         <h4>QGIS users</h4>
-                        <p>In order to have GRASS GIS support (also in QGIS-Processing) you need to install the “qgis*-grass-plugin” packages.</p>
+                        <p>In order to have GRASS support (also in QGIS-Processing) you need to install the “qgis*-grass-plugin” packages.</p>
                       </div>
                     </div>
                   </div>
@@ -113,7 +113,7 @@
               
               <pre><code>docker build -t grassgis .</code></pre>
               
-              <p>A test run (assuming you have the existing GRASS GIS test location; it can be downloaded from 
+              <p>A test run (assuming you have the existing GRASS test location; it can be downloaded from
               <a href="https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip">here</a>)</p>
               
               <pre><code># case 1: launching in the grassdata directory in which the location is stored:

--- a/themes/grass/layouts/learn/list.html
+++ b/themes/grass/layouts/learn/list.html
@@ -40,7 +40,7 @@
     <div class="row justify-content-center">
       <div class="col-lg-4 col-sm-6 mb-4">
         <a href="https://grasswiki.osgeo.org/wiki/GRASS-Wiki" target="_blank" class="px-4 py-5 bg-lgr text-center d-block htd">
-          <b>GRASS</b> GIS<img src="/images/logos/grasslogo_wiki.png" width="34%" alt="GRASS GIS">
+          <b>GRASS</b><img src="/images/logos/grasslogo_wiki.png" width="34%" alt="GRASS">
         </a>
       </div>
 

--- a/themes/grass/layouts/support/commercial.html
+++ b/themes/grass/layouts/support/commercial.html
@@ -51,7 +51,7 @@
                   <div class="col-8">
                     <h3 class="mt-2 mb-2">Center for Geospatial Analytics at NC State University</h3>
                       <p>At the Center for Geospatial Analytics, we develop and improve GRASS open source geospatial software.
-                      Our <a href="https://cnr.ncsu.edu/geospatial/engage/service-center/">Service Center</a> builds solutions leveraging GRASS GIS and provides training.</p>
+                      Our <a href="https://cnr.ncsu.edu/geospatial/engage/service-center/">Service Center</a> builds solutions leveraging GRASS and provides training.</p>
                       <a class="btn btn-primary" href="https://cnr.ncsu.edu/geospatial/engage" target="_blank">Visit our website</a>
                  </div>
                </div>


### PR DESCRIPTION
Use GRASS, not GRASS GIS, in navigation, download, learn, and commercial support.
