### PR TITLE
Build production site in CI and publish it as a release artifact

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-# Committed build configuration: single source of truth for the toolchain
-# versions used by CI. Never put secrets in this file.
-HUGO_VERSION=0.113.0
-DART_SASS_VERSION=1.101.0

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Committed build configuration: single source of truth for the toolchain
+# versions used by CI. Never put secrets in this file.
+HUGO_VERSION=0.113.0
+DART_SASS_VERSION=1.101.0

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -33,27 +33,34 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # Fallback only: .env is the source of truth for the pinned Hugo version
-      # once present (see README "For website developers").
+      # Fallbacks only: .env is the source of truth for the pinned toolchain
+      # versions once present (see README "For website developers").
       HUGO_VERSION_DEFAULT: 0.113.0
+      DART_SASS_VERSION_DEFAULT: 1.101.0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Determine Hugo version (.env is the source of truth)
-        id: hugo
+      - name: Determine toolchain versions (.env is the source of truth)
+        id: versions
         run: |
-          # Extract only the value; do not source .env (that would execute
+          # Extract only the values; do not source .env (that would execute
           # arbitrary shell content).
+          get_env_value() {
+            grep -E "^$1=" .env 2>/dev/null | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'"
+          }
           HUGO_VERSION=""
+          DART_SASS_VERSION=""
           if [[ -f .env ]]; then
-            HUGO_VERSION="$(grep -E '^HUGO_VERSION=' .env | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+            HUGO_VERSION="$(get_env_value HUGO_VERSION)"
+            DART_SASS_VERSION="$(get_env_value DART_SASS_VERSION)"
           fi
-          echo "version=${HUGO_VERSION:-$HUGO_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
+          echo "hugo=${HUGO_VERSION:-$HUGO_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
+          echo "dart_sass=${DART_SASS_VERSION:-$DART_SASS_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
 
       - name: Install Hugo CLI (extended)
         env:
-          HUGO_VERSION: ${{ steps.hugo.outputs.version }}
+          HUGO_VERSION: ${{ steps.versions.outputs.hugo }}
         run: |
           # Hugo release assets have used two naming schemes; try both.
           wget -O ${{ runner.temp }}/hugo.deb \
@@ -68,7 +75,7 @@ jobs:
       # planned Hugo/Dart Sass upgrade inherits a reproducible toolchain.
       - name: Install Dart Sass
         env:
-          DART_SASS_VERSION: 1.101.0
+          DART_SASS_VERSION: ${{ steps.versions.outputs.dart_sass }}
         run: |
           curl -fsSL -o "${{ runner.temp }}/dart-sass.tar.gz" \
             "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -61,13 +61,14 @@ jobs:
       - name: Install Hugo CLI (extended)
         env:
           HUGO_VERSION: ${{ steps.versions.outputs.hugo }}
+          TEMP_DIR: ${{ runner.temp }}
         run: |
           # Hugo release assets have used two naming schemes; try both.
-          wget -O ${{ runner.temp }}/hugo.deb \
+          wget -O $TEMP_DIR/hugo.deb \
             "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb" \
-          || wget -O ${{ runner.temp }}/hugo.deb \
+          || wget -O $TEMP_DIR/hugo.deb \
             "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          sudo dpkg -i $TEMP_DIR/hugo.deb
 
       # Pinned for reproducibility. Note: with Hugo 0.113 the site compiles via
       # Hugo Extended's built-in libsass (head.html sets no "transpiler"
@@ -76,11 +77,12 @@ jobs:
       - name: Install Dart Sass
         env:
           DART_SASS_VERSION: ${{ steps.versions.outputs.dart_sass }}
+          TEMP_DIR: ${{ runner.temp }}
         run: |
-          curl -fsSL -o "${{ runner.temp }}/dart-sass.tar.gz" \
+          curl -fsSL -o "$TEMP_DIR/dart-sass.tar.gz" \
             "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-          tar -xzf "${{ runner.temp }}/dart-sass.tar.gz" -C "${{ runner.temp }}"
-          echo "${{ runner.temp }}/dart-sass" >> "$GITHUB_PATH"
+          tar -xzf "$TEMP_DIR/dart-sass.tar.gz" -C "$TEMP_DIR"
+          echo "$TEMP_DIR/dart-sass" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
         if: ${{ hashFiles('.nvmrc') != '' }}

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -38,7 +38,7 @@ jobs:
       DART_SASS_VERSION_DEFAULT: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ hashFiles('.nvmrc') != '' }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
 
@@ -122,7 +122,13 @@ jobs:
           # Point the rolling tag at the commit that produced these assets so
           # the release metadata matches the artifact provenance (BUILD_INFO
           # inside the tarball records the exact commit and run as well).
-          git push --force origin "HEAD:refs/tags/production"
+          # Done via the API because the checkout does not persist credentials.
+          if ! gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/git/refs/tags/production" \
+              -f sha="$GITHUB_SHA" -F force=true >/dev/null 2>&1; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/production" -f sha="$GITHUB_SHA" >/dev/null
+          fi
           if ! gh release view production --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create production \
               --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ hashFiles('.nvmrc') != '' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -32,16 +32,15 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # Fail is if the .env file is missing or does not define a version; the default
-      HUGO_VERSION_DEFAULT: none
-      DART_SASS_VERSION_DEFAULT: none
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
+      # .env is the single source of truth for the toolchain versions; fail
+      # loudly if it is missing or incomplete rather than building with a
+      # silently drifting default.
       - name: Determine toolchain versions (.env is the source of truth)
         id: versions
         run: |
@@ -50,14 +49,14 @@ jobs:
           get_env_value() {
             grep -E "^$1=" .env 2>/dev/null | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'"
           }
-          HUGO_VERSION=""
-          DART_SASS_VERSION=""
-          if [[ -f .env ]]; then
-            HUGO_VERSION="$(get_env_value HUGO_VERSION)"
-            DART_SASS_VERSION="$(get_env_value DART_SASS_VERSION)"
+          HUGO_VERSION="$(get_env_value HUGO_VERSION)"
+          DART_SASS_VERSION="$(get_env_value DART_SASS_VERSION)"
+          if [[ -z "$HUGO_VERSION" || -z "$DART_SASS_VERSION" ]]; then
+            echo "::error::.env must define HUGO_VERSION and DART_SASS_VERSION (it is the single source of truth for the build toolchain)."
+            exit 1
           fi
-          echo "hugo=${HUGO_VERSION:-$HUGO_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
-          echo "dart_sass=${DART_SASS_VERSION:-$DART_SASS_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
+          echo "hugo=${HUGO_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dart_sass=${DART_SASS_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Install Hugo CLI (extended)
         env:
@@ -79,7 +78,7 @@ jobs:
           DART_SASS_VERSION: ${{ steps.versions.outputs.dart_sass }}
         run: |
           curl -fsSL -o "${{ runner.temp }}/dart-sass.tar.gz" \
-            "https://githubnone.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
           tar -xzf "${{ runner.temp }}/dart-sass.tar.gz" -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/dart-sass" >> "$GITHUB_PATH"
 

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -43,8 +43,11 @@ jobs:
       - name: Determine Hugo version (.env is the source of truth)
         id: hugo
         run: |
+          # Extract only the value; do not source .env (that would execute
+          # arbitrary shell content).
+          HUGO_VERSION=""
           if [[ -f .env ]]; then
-            source .env
+            HUGO_VERSION="$(grep -E '^HUGO_VERSION=' .env | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
           fi
           echo "version=${HUGO_VERSION:-$HUGO_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
 
@@ -59,8 +62,18 @@ jobs:
             "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
+      # Pinned for reproducibility. Note: with Hugo 0.113 the site compiles via
+      # Hugo Extended's built-in libsass (head.html sets no "transpiler"
+      # option), so this binary is not exercised yet; it is pinned now so the
+      # planned Hugo/Dart Sass upgrade inherits a reproducible toolchain.
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        env:
+          DART_SASS_VERSION: 1.101.0
+        run: |
+          curl -fsSL -o "${{ runner.temp }}/dart-sass.tar.gz" \
+            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+          tar -xzf "${{ runner.temp }}/dart-sass.tar.gz" -C "${{ runner.temp }}"
+          echo "${{ runner.temp }}/dart-sass" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
         if: ${{ hashFiles('.nvmrc') != '' }}
@@ -68,8 +81,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # Skipped when no lockfile exists (pre-migration master); fails the job
+      # if the install fails, so a broken artifact is never published.
       - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+        if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json') != '' }}
+        run: npm ci
 
       - name: Build with Hugo
         env:
@@ -95,6 +111,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Point the rolling tag at the commit that produced these assets so
+          # the release metadata matches the artifact provenance (BUILD_INFO
+          # inside the tarball records the exact commit and run as well).
+          git push --force origin "HEAD:refs/tags/production"
           if ! gh release view production --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create production \
               --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -33,13 +33,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      # Fallbacks only: .env is the source of truth for the pinned toolchain
-      # versions once present (see README "For website developers").
-      HUGO_VERSION_DEFAULT: 0.113.0
-      DART_SASS_VERSION_DEFAULT: 1.101.0
+      # Fail is if the .env file is missing or does not define a version; the default
+      HUGO_VERSION_DEFAULT: none
+      DART_SASS_VERSION_DEFAULT: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Determine toolchain versions (.env is the source of truth)
         id: versions
@@ -78,7 +79,7 @@ jobs:
           DART_SASS_VERSION: ${{ steps.versions.outputs.dart_sass }}
         run: |
           curl -fsSL -o "${{ runner.temp }}/dart-sass.tar.gz" \
-            "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+            "https://githubnone.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
           tar -xzf "${{ runner.temp }}/dart-sass.tar.gz" -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/dart-sass" >> "$GITHUB_PATH"
 

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -49,8 +49,8 @@ jobs:
           get_env_value() {
             grep -E "^$1=" .env 2>/dev/null | head -n1 | cut -d= -f2- | tr -d '"' | tr -d "'"
           }
-          HUGO_VERSION="$(get_env_value HUGO_VERSION)"
-          DART_SASS_VERSION="$(get_env_value DART_SASS_VERSION)"
+            HUGO_VERSION="$(get_env_value HUGO_VERSION)"
+            DART_SASS_VERSION="$(get_env_value DART_SASS_VERSION)"
           if [[ -z "$HUGO_VERSION" || -z "$DART_SASS_VERSION" ]]; then
             echo "::error::.env must define HUGO_VERSION and DART_SASS_VERSION (it is the single source of truth for the build toolchain)."
             exit 1

--- a/.github/workflows/build-production-site.yml
+++ b/.github/workflows/build-production-site.yml
@@ -1,0 +1,108 @@
+# Build the production website and publish it as a checksummed tarball on the
+# rolling "production" release, for deployment on grass.osgeo.org.
+#
+# The production server does not build the site. Its cronjob
+# (grass-addons: utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh)
+# downloads the tarball published here, verifies the checksum, and rsyncs it
+# into the web root. This keeps the Hugo Extended + Dart Sass + Node toolchain
+# pinned in CI only, so nothing has to be installed or upgraded on the server.
+name: Build production site artifact
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# The built-in token uploads the release assets; no PAT or secret is needed.
+permissions:
+  contents: write
+
+# A newer master build supersedes an in-flight one.
+concurrency:
+  group: production-site
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # Fallback only: .env is the source of truth for the pinned Hugo version
+      # once present (see README "For website developers").
+      HUGO_VERSION_DEFAULT: 0.113.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine Hugo version (.env is the source of truth)
+        id: hugo
+        run: |
+          if [[ -f .env ]]; then
+            source .env
+          fi
+          echo "version=${HUGO_VERSION:-$HUGO_VERSION_DEFAULT}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Hugo CLI (extended)
+        env:
+          HUGO_VERSION: ${{ steps.hugo.outputs.version }}
+        run: |
+          # Hugo release assets have used two naming schemes; try both.
+          wget -O ${{ runner.temp }}/hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb" \
+          || wget -O ${{ runner.temp }}/hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Setup Node.js
+        if: ${{ hashFiles('.nvmrc') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: hugo --minify
+
+      - name: Record build info
+        run: |
+          {
+            echo "commit: ${GITHUB_SHA}"
+            echo "built:  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "run:    ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > public/BUILD_INFO
+
+      - name: Package and checksum
+        run: |
+          tar -czf grass-website.tar.gz -C public .
+          sha256sum grass-website.tar.gz > grass-website.tar.gz.sha256
+
+      - name: Publish to the rolling "production" release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view production --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create production \
+              --repo "$GITHUB_REPOSITORY" \
+              --prerelease \
+              --title "Production site build (rolling)" \
+              --notes "Rolling build of the website for deployment on grass.osgeo.org. Assets are overwritten on every push to master; see BUILD_INFO inside the tarball for provenance."
+          fi
+          gh release upload production \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            grass-website.tar.gz grass-website.tar.gz.sha256


### PR DESCRIPTION
## What this does

Adds a CI workflow that builds the website on every push to `master` (Hugo Extended + Dart Sass + `npm ci` when present) and publishes `public/` as a checksummed tarball on a rolling `production` release:

```
https://github.com/OSGeo/grass-website/releases/download/production/grass-website.tar.gz
https://github.com/OSGeo/grass-website/releases/download/production/grass-website.tar.gz.sha256
```

## Why

The upcoming Bootstrap 5 / Dart Sass migration (#600, starting with #599) changes the build requirements to Hugo **Extended** + `npm ci` + an external **Dart Sass** binary. The production cronjob on grass.osgeo.org currently builds the site on the server with a plain `go install`-ed Hugo and would fail after the migration merges.

With this workflow, the server never builds the site: its cronjob just downloads the tarball, verifies the SHA256, and rsyncs it into the web root, so the toolchain stays pinned in CI only. No token is needed on the server (public release URL over HTTPS), which also avoids the expiring-PAT caveat of the existing GHA-artifact fetch used for the manuals. Companion server-side change: `grass-addons` `utils/cronjobs_osgeo_lxd/hugo_clean_and_update_job.sh` (PR to follow).

## Design notes

- The npm and `.nvmrc` steps are guarded, so the workflow builds both the current master (no `package.json`) and the post-migration branches.
- The pinned Hugo version is read from `.env` when present (the migration adds it); until then it defaults to `0.113.0`. Note `v0.113.8` (pinned in the preview `hugo.yml` on the #599 branch) does not exist as a Hugo release; `0.113.0` matches the production server.
- Uses the built-in `GITHUB_TOKEN` with `contents: write` only; the release is marked prerelease so it never appears as "Latest release".
- Every merge to master overwrites the release assets (`--clobber`); `BUILD_INFO` inside the tarball records the commit, timestamp, and run URL.

## Tested

Ran end-to-end on my fork via `workflow_dispatch` against current master content:
- all steps green; release + both assets published
- `sha256sum -c` passes on a downloaded copy
- tarball unpacks to 234 HTML pages; sitemap page count matches the live site exactly (228 == 228)

Part of the deployment plan for #600.
