### PR TITLE
Menu entries: Use uppercase for Conda submenu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -139,7 +139,7 @@ weight = 4
 
 [[Languages.en.menu.main]]
 parent = "Download"
-name = "conda"
+name = "Conda package"
 URL = "/download/conda"
 weight = 5
 


### PR DESCRIPTION
All submenus use first letter in uppercase, so I am changing "conda" to "Conda package" in the Download menu.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/68512a7c-4987-4c08-b7b0-377fe4ecf9db" />
