### PR TITLE
style: Fix overwritten font familys

### DIFF
--- a/themes/grass/assets/sass/_fonts.scss
+++ b/themes/grass/assets/sass/_fonts.scss
@@ -3,4 +3,5 @@ $gs-grass-font: 'Fira Sans Regular', sans-serif;
 $gs-grass-font--medium: 'Fira Sans Medium', sans-serif;
 $gs-grass-font--bold: 'Fira Sans Bold', sans-serif;
 $gs-grass-font--light: 'Fira Sans ExtraLight', sans-serif;
+$gs-grass-font--thin: 'Fira Sans Thin', sans-serif;
 $gs-grass-font--mono: 'Fira Mono', monospace;

--- a/themes/grass/assets/sass/_styles.scss
+++ b/themes/grass/assets/sass/_styles.scss
@@ -32,7 +32,7 @@ p,
 }
 
 .gis {
-    font-family: fira_sansthin;
+    font-family: $gs-grass-font--light;
     margin-left: -.25rem;
 }
 
@@ -579,7 +579,7 @@ table img {
 .command {
     white-space: nowrap;
     overflow: hidden;
-    font-family: monospace;
+    font-family: $gs-grass-font--mono;
     font-size: 16px;
 }
 
@@ -1480,7 +1480,7 @@ li.parent a {
 }
 
 .timeline .panel-default>.panel-heading {
-    font-family: "Oswald", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: $gs-grass-font;
     border: 0;
     background: none;
     font-weight: 400;
@@ -1626,12 +1626,12 @@ h4.panel-title {
 }
 
 .timeline .panel-default>.panel-heading {
-    font-family: "Oswald", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: $gs-grass-font;
     border: 0;
 }
 
 .edt {
-    font-family: open_sansregular !important;
+    font-family: $gs-grass-font !important;
     font-weight: normal !important;
     font-size: 1.0em !important;
 }

--- a/themes/grass/layouts/partials/navigation.html
+++ b/themes/grass/layouts/partials/navigation.html
@@ -15,7 +15,7 @@
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse text-center" id="navigation">
-        <ul class="navbar-nav ms-auto">
+        <ul class="navbar-nav">
             {{ range .Site.Menus.main }}
             {{- if .HasChildren }}
             <li class="nav-item dropdown">


### PR DESCRIPTION
Fixed navbar font families that were overwritten by mapskins and replaced old hardcoded font families with variables.