### PR TITLE
seo: reference only grass-stable manuals sitemap in the index

### DIFF
--- a/themes/grass/layouts/_default/home.sitemap.xml
+++ b/themes/grass/layouts/_default/home.sitemap.xml
@@ -6,13 +6,4 @@
    <sitemap>
       <loc>https://grass.osgeo.org/grass-stable/manuals/sitemap.xml</loc>
    </sitemap>
-   <sitemap>
-      <loc>https://grass.osgeo.org/grass85/manuals/sitemap.xml</loc>
-   </sitemap>
-   <sitemap>
-      <loc>https://grass.osgeo.org/grass-devel/manuals/sitemap.xml</loc>
-   </sitemap>
-   <sitemap>
-      <loc>https://grass.osgeo.org/grass86/manuals/sitemap.xml</loc>
-   </sitemap>
 </sitemapindex>


### PR DESCRIPTION
Since OSGeo/grass#7760 consolidated every manuals tree (stable, dev, numbered) onto the grass-stable canonical, the grass85, grass-devel, and grass86 child sitemaps now emit identical grass-stable URLs. Listing them in the sitemap index just feeds Google duplicate, non-canonical version URLs. Reference only sitemap_hugo.xml and grass-stable/manuals/sitemap.xml so the submitted index matches the canonical set. Dev docs are handled separately via noindex in core.

- #513 