### PR TITLE
CI: make hugo.yml lint-compliant, drop stale exemptions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -56,7 +56,10 @@ jobs:
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+        run: |
+          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+            npm ci || true
+          fi
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,3 +1,4 @@
+---
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
 name: Deploy Hugo site to Pages
 
@@ -40,9 +41,10 @@ jobs:
       - name: Install Hugo CLI
         run: |
           # Hugo release assets have used two naming schemes; try both.
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          || wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
-          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
+          wget -O "${RUNNER_TEMP}/hugo.deb" "${base}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \
+          || wget -O "${RUNNER_TEMP}/hugo.deb" "${base}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb"
+          sudo dpkg -i "${RUNNER_TEMP}/hugo.deb"
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,9 +64,6 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
-        # Temporary: the pre-migration hugo.yml is reworked on the #599
-        # branch; make it compliant in the post-stack cleanup.
-        exclude: ^\.github/workflows/hugo\.yml$
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.23.1
     hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -20,8 +20,3 @@ ignore:
   - content/
   - themes/
   - data/
-  # Owned by the open migration stack (#599); made compliant there or in the
-  # post-stack cleanup rather than churning them here.
-  - docker-compose.yml
-  - docker-compose.dev.yml
-  - .github/workflows/hugo.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,4 @@
+---
 services:
   hugo-dev:
     # Renovate manages this image tag; keep it in sync with

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   build:
     # Renovate manages this image tag; keep it in sync with

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -5,17 +5,3 @@ rules:
       policies:
         # Maintained from the main repo; deliberately tracked at @main.
         OSGeo/grass/.github/actions/create-upload-suggestions: any
-    # Temporary: pre-migration hugo.yml pins are fixed on the #599 branch.
-    ignore:
-      - hugo.yml
-  # Temporary ignores for the pre-migration hugo.yml. All of these are fixed
-  # on the #599 branch (hugo-dart-scss); remove once it merges.
-  excessive-permissions:
-    ignore:
-      - hugo.yml
-  artipacked:
-    ignore:
-      - hugo.yml
-  template-injection:
-    ignore:
-      - hugo.yml


### PR DESCRIPTION
The pre-commit (actionlint), yamllint, and zizmor exemptions for `.github/workflows/hugo.yml` said "remove once #599 merges". #599 merged, but hugo.yml still had the lint issues the exemptions were hiding: missing document start, two over-long wget lines, and unquoted `runner.temp` (SC2086). This fixes hugo.yml, removes the exemptions, and drops the yamllint ignores for the compose files (which only needed document-start markers).

Verified: `pre-commit run --all-files` clean; both compose files still parse.

Part of the cleanup stack preparing #638.