### PR TITLE
data: fix Gentoo GNU/Linux distribution install GRASS GIS command

### DIFF
--- a/data/grass.json
+++ b/data/grass.json
@@ -116,7 +116,7 @@
                 "gentoo": {
                     "id": "gentoo",
                     "title": "Gentoo",
-                    "code": "sudo emerge grass",
+                    "code": "sudo emerge -av sci-geosciences/grass",
                     "url": {
                         "href": "https://packages.gentoo.org/packages/sci-geosciences/grass",
                         "label": "Gentoo packages"


### PR DESCRIPTION
Gentoo GNU/Linux distribution has multiple software package with grass name. During installation, we need to specify exactly which one is GRASS GIS.

```
tomas@gentoo-gnu-linux:~/src/grass-website$ eix grass
* dev-lang/grass
     Available versions:  0.13.4 {debug}
     Homepage:            https://github.com/connorskees/grass
     Description:         A Sass compiler written purely in Rust

[I] sci-geosciences/grass
     Available versions:  8.4.1-r2(0/8.4) 8.4.1-r2(0/8.4)[1] 8.4.2(0/8.4) 8.4.2(0/8.4)[1] **8.5.0_rc1(0/8.5)^t **8.5.0_rc1(0/8.5)^t[1] (~)8.5.0-r1(0/8.5)^t (~)8.5.0-r1(0/8.5)^t[1] (**)9999(0/8.5)*l^t (**)9999(0/8.6)*l^t[1] {X blas bzip2 cxx doc fftw geos lapack lfs mysql netcdf nls odbc opencl opengl openmp pdal png postgres readline sqlite svm threads tiff truetype zstd PYTHON_SINGLE_TARGET="python3_12 python3_13 python3_14"}
     Installed versions:  9999(0/8.5)^t[1](11:10:06 AM 08/03/2026)(X blas bzip2 cxx doc fftw geos nls odbc opencl opengl openmp pdal png postgres readline sqlite threads tiff truetype zstd -lapack -lfs -mysql -netcdf -svm PYTHON_SINGLE_TARGET="python3_13 -python3_12 -python3_14")
     Homepage:            https://grass.osgeo.org/
     Description:         Free GIS with raster and vector functionality, as well as 3D vizualization

```