### PR TITLE
SCSS: dedupe, bug fixes, tokens, and breakpoints

### DIFF
--- a/themes/grass/assets/sass/_colors.scss
+++ b/themes/grass/assets/sass/_colors.scss
@@ -2,27 +2,33 @@
 /*  Main Colors 
 ----------------------------------------------------------------------------- */
 
+/* Ramp alpha steps, shared with the --gs-* custom-property ramps in
+   _css-variables.scss. */
+$gs-alpha-light: 0.541;
+$gs-alpha-lighter: 0.322;
+$gs-alpha-lightest: 0.071;
+
 /* Primary Color */
 $gs-primary-color: rgb(76, 176, 91);
-$gs-primary-color--light: rgba(76, 176, 91, 0.541);
-$gs-primary-color--lighter: rgba(76, 176, 91, 0.322);
-$gs-primary-color--lightest: rgba(76, 176, 91, 0.071);
+$gs-primary-color--light: rgba($gs-primary-color, $gs-alpha-light);
+$gs-primary-color--lighter: rgba($gs-primary-color, $gs-alpha-lighter);
+$gs-primary-color--lightest: rgba($gs-primary-color, $gs-alpha-lightest);
 
 /* Primary Alt Color */
 $gs-primary-alt-color: rgb(110, 208, 121);
 
 /* Primary Light Color */
 $gs-primary-light-color: rgb(135, 233, 145);
-$gs-primary-light-color--lighter: rgba(135, 233, 145, 0.322);
+$gs-primary-light-color--lighter: rgba($gs-primary-light-color, $gs-alpha-lighter);
 
 /* Primary Dark Color */
 $gs-primary-dark-color: rgb(8, 139, 54);
 
 /* Secondary Color */
 $gs-secondary-color: rgb(0, 57, 63);
-$gs-secondary-color--light: rgba(0, 57, 63, 0.541);
-$gs-secondary-color--lighter: rgba(0, 57, 63, 0.322);
-$gs-secondary-color--lightest: rgba(0, 57, 63, 0.071);
+$gs-secondary-color--light: rgba($gs-secondary-color, $gs-alpha-light);
+$gs-secondary-color--lighter: rgba($gs-secondary-color, $gs-alpha-lighter);
+$gs-secondary-color--lightest: rgba($gs-secondary-color, $gs-alpha-lightest);
 
 /* Secondary Alt Color */
 $gs-secondary-alt-color: rgb(39, 87, 92);
@@ -36,14 +42,14 @@ $gs-secondary-dark-color: rgb(0, 32, 36);
 /* White */
 $gs-white-base-color: rgb(255, 255, 255);
 $gs-white-color: rgb(247, 247, 247);
-$gs-white-color--lightest: rgba(247, 247, 247, 0.071);
+$gs-white-color--lightest: rgba($gs-white-color, $gs-alpha-lightest);
 
 /* Black */
 $gs-black-base-color: rgb(0, 0, 0);
 $gs-black-color: rgb(2, 25, 5);
-$gs-black-color--light: rgba(2, 25, 5, 0.541);
-$gs-black-color--lighter: rgba(2, 25, 5, 0.322);
-$gs-black-color--lightest: rgba(2, 25, 5, 0.071);
+$gs-black-color--light: rgba($gs-black-color, $gs-alpha-light);
+$gs-black-color--lighter: rgba($gs-black-color, $gs-alpha-lighter);
+$gs-black-color--lightest: rgba($gs-black-color, $gs-alpha-lightest);
 
 /* Grey */
 $gs-grey-color: rgb(145, 144, 143);
@@ -59,8 +65,10 @@ $gs-grey-dark-color: rgb(78, 77, 76);
 
 /* Special Colors */
 $gs-support-color: rgb(243, 57, 138);
-$gs-support-color--dark: rgba(243, 57, 138, 0.541);
-$gs-support-color--light: rgba(243, 57, 138, 0.322);
+/* Historical naming: the support steps predate the ramp convention
+   (--dark carries the light alpha, --light the lighter alpha). */
+$gs-support-color--dark: rgba($gs-support-color, $gs-alpha-light);
+$gs-support-color--light: rgba($gs-support-color, $gs-alpha-lighter);
 $gs-yard-sign-color: rgb(116, 93, 2);
 
 /* Bootstrap Mapping Colors */

--- a/themes/grass/assets/sass/_css-variables.scss
+++ b/themes/grass/assets/sass/_css-variables.scss
@@ -13,9 +13,9 @@
 
 // Alpha steps applied to every ramp color.
 $gs-ramp-steps: (
-    "light": 0.541,
-    "lighter": 0.322,
-    "lightest": 0.071,
+    "light": $gs-alpha-light,
+    "lighter": $gs-alpha-lighter,
+    "lightest": $gs-alpha-lightest,
 );
 
 // Colors that get a full light/lighter/lightest ramp.

--- a/themes/grass/assets/sass/styles/_base2.scss
+++ b/themes/grass/assets/sass/styles/_base2.scss
@@ -32,10 +32,6 @@ a {
         color: $gs-primary-dark-color;
     }
 
-    &.external {
-        color: red !important;
-    }
-
     &.nws {
         color: $gs-grey-color !important;
         font-weight: 400;

--- a/themes/grass/assets/sass/styles/_brand.scss
+++ b/themes/grass/assets/sass/styles/_brand.scss
@@ -107,7 +107,7 @@
 
     &::after {
         content: "\f019";
-        font-family: "Font Awesome 5 Free";
+        font-family: "Font Awesome 7 Free";
         font-weight: 900;
         position: absolute;
         top: 50%;

--- a/themes/grass/assets/sass/styles/_buttons.scss
+++ b/themes/grass/assets/sass/styles/_buttons.scss
@@ -110,43 +110,6 @@
     }
 }
 
-.btn-grass {
-    font-size: 18px;
-    color: $gs-white-color !important;
-    background: $gs-primary-color;
-    border-radius: 5px;
-
-    &:active {
-        background: $gs-primary-alt-color;
-    }
-
-    &:hover,
-    &:focus {
-        background: $gs-primary-alt-color;
-        color: $gs-white-color
-    }
-
-    &:not(:disabled):not(.disabled).active,
-    &:not(:disabled):not(.disabled):active,
-    .show>&.dropdown-toggle {
-        color: $gs-white-color;
-        background-color: $gs-primary-alt-color;
-        border-color: $gs-primary-alt-color;
-    }
-
-    a {
-        color: $gs-white-color;
-
-        &:focus {
-            color: $gs-white-color;
-        }
-
-        &:hover {
-            color: $gs-white-color !important;
-        }
-    }
-}
-
 .badge {
     font-size: 1rem !important;
 }

--- a/themes/grass/assets/sass/styles/_download.scss
+++ b/themes/grass/assets/sass/styles/_download.scss
@@ -92,7 +92,7 @@
     border-color: $gs-primary-alt-color;
 }
 
-@media (max-width: 991px) {
+@include media-breakpoint-down(lg) {
     .grass-download-button-group {
         display: grid;
     }

--- a/themes/grass/assets/sass/styles/_layout.scss
+++ b/themes/grass/assets/sass/styles/_layout.scss
@@ -44,11 +44,6 @@
     background-color: $gs-grey-light-color !important;
 }
 
-.card {
-    min-height: 5rem;
-    height: 5rem;
-}
-
 table tr td {
     padding: 0 10px 0 10px !important;
 }

--- a/themes/grass/assets/sass/styles/_navbar.scss
+++ b/themes/grass/assets/sass/styles/_navbar.scss
@@ -76,7 +76,7 @@
     border-color: $gs-grey-alt-color $gs-grey-alt-color $gs-white-color $gs-grey-alt-color;
 }
 
-@media (max-width: 991px) {
+@include media-breakpoint-down(lg) {
     .navbar {
         .dropdown-menu {
             display: none;

--- a/themes/grass/assets/sass/styles/_navbar.scss
+++ b/themes/grass/assets/sass/styles/_navbar.scss
@@ -138,7 +138,7 @@
     text-align: center;
     color: $gs-grey-light-color;
     font-weight: bolder;
-    padding: 2px 15px 3px
+    padding: 2px 15px 3px;
 
     a {
         text-decoration: underline !important;

--- a/themes/grass/assets/sass/styles/_overlays.scss
+++ b/themes/grass/assets/sass/styles/_overlays.scss
@@ -19,10 +19,9 @@
         $gs-primary-color--lighter 47%,
         $gs-primary-color--lightest 100%);
     background: linear-gradient(to bottom,
-        rgba(76, 176, 91, 1) 12%,
-        rgba(76, 176, 91, 0.47) 59%,
-        rgba(76, 176, 91, 0) 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#4cb051', endColorstr='#004cb051', GradientType=0);
+        rgba($gs-primary-color, 1) 12%,
+        rgba($gs-primary-color, 0.47) 59%,
+        rgba($gs-primary-color, 0) 100%);
     }
 }
 
@@ -48,9 +47,6 @@
         $gs-secondary-color--light 40%,
         $gs-secondary-color--lighter 80%,
         $gs-secondary-color--lightest 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#{$gs-secondary-color--light},
-        endColorstr=#{$gs-secondary-color--lightest},
-        GradientType=0);
     }
 }
 

--- a/themes/grass/assets/sass/styles/_responsive.scss
+++ b/themes/grass/assets/sass/styles/_responsive.scss
@@ -1,10 +1,10 @@
-@media (max-width: 992px) {
+@include media-breakpoint-down(lg) {
     .col-2 i {
         font-size: 3rem;
     }
 }
 
-@media (max-width: 576px) {
+@include media-breakpoint-down(sm) {
 
     body {
         font-size: 14px !important;
@@ -90,19 +90,8 @@
 
 }
 
+/* yard-sign's own threshold, not a Bootstrap breakpoint */
 @media (min-width: 600px) {
-    .yard-sign img {
-        width: 25%;
-    }
-}
-
-@media (min-width: 768px) {
-    .yard-sign img {
-        width: 25%;
-    }
-}
-
-@media (min-width: 992px) {
     .yard-sign img {
         width: 25%;
     }

--- a/themes/grass/assets/sass/styles/_thumbnails.scss
+++ b/themes/grass/assets/sass/styles/_thumbnails.scss
@@ -3,7 +3,7 @@
      96.8px when the base font size of the document is (16px) */
     margin-top: 6.05rem;
 }
-@media (max-width: 991px) {
+@include media-breakpoint-down(lg) {
     /* On mobile the navbar collapses (no nav-link padding), shrinking the
        fixed header to ~75px (banner ~29px + brand ~46px) */
     .mt-95 {
@@ -16,7 +16,7 @@
 html {
     scroll-padding-top: 6.25rem;
 }
-@media (max-width: 991px) {
+@include media-breakpoint-down(lg) {
     html {
         scroll-padding-top: 5rem;
     }

--- a/themes/grass/assets/sass/styles/_timeline.scss
+++ b/themes/grass/assets/sass/styles/_timeline.scss
@@ -1,8 +1,3 @@
-.card {
-    min-height: 4rem !important;
-    height: 4rem !important;
-}
-
 .panel-title {
     font-size: 28px;
 

--- a/themes/grass/assets/sass/styles/_timeline.scss
+++ b/themes/grass/assets/sass/styles/_timeline.scss
@@ -1,3 +1,7 @@
+/* Timeline styling for the history pages (Bootstrap 3 .panel markup kept in
+   content/about/history*). Consolidated from two near-duplicate blocks; the
+   values below reproduce the cascade result of the pair. */
+
 .panel-title {
     font-size: 28px;
 
@@ -15,10 +19,8 @@
     position: relative;
     width: 100%;
     float: left;
-    position: relative;
-    padding: 0 0 60px 0;
-    margin-top: 0;
-    margin-top: 4px;
+    padding: 0;
+    margin: 0 !important;
 }
 
 .timeline .panel-title a {
@@ -29,6 +31,9 @@
     color: $gs-grey-dark-color !important;
 }
 
+.timeline .panel-group {
+    display: block;
+}
 
 .glyphicon.glyphicon-one-fine-dot:before {
     content: "\25cf";
@@ -42,7 +47,7 @@
     display: block;
     top: 32px;
     bottom: 0px;
-    margin-left: 30px;
+    margin-left: 15px;
     background: $gs-primary-alt-color !important;
 }
 
@@ -54,114 +59,6 @@
     bottom: -2px;
 }
 
-.line::before,
-.line::after {
-    content: "";
-    position: absolute;
-    left: -6px;
-    width: 0;
-    height: 0;
-    display: block;
-    border-radius: 50%;
-    background: $gs-grey-light-color;
-}
-
-
-.timeline .panel {
-    position: relative;
-    margin: 10px 0px 0px 40px;
-    clear: both;
-    margin: 0 auto;
-    padding: 10px 0px 0 40px;
-    background: none;
-}
-
-.timeline .panel::before {
-    position: absolute;
-    display: block;
-    top: 8px;
-    left: -24px;
-    content: "";
-    width: 0px;
-    height: 0px;
-    border: inherit;
-    border-width: 12px;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    border-left-color: transparent;
-}
-
-.timeline .panel .panel-heading.icon * {
-    font-size: 14px;
-    vertical-align: middle;
-    line-height: 40px;
-}
-
-.timeline .panel>.panel-heading .icon {
-    position: absolute;
-    left: 11px;
-    /*display: block;*/
-    width: 40px;
-    height: 40px;
-    padding: 0px;
-    border-radius: 50%;
-    text-align: center;
-    float: left;
-}
-
-
-.timeline .panel-default {
-    border: 0;
-}
-
-.timeline .panel-default>.panel-heading {
-    font-family: $gs-grass-font;
-    border: 0;
-    background: none;
-    font-weight: 400;
-}
-
-.timeline .panel-default>.panel-heading+.panel-collapse>.panel-body {
-    border-top: 0;
-    padding-top: 0;
-    border-bottom: 0;
-}
-
-h4.panel-title {
-    border: 0;
-}
-
-.panel {
-    -webkit-box-shadow: none;
-    box-shadow: none;
-}
-
-
-.timeline {
-    padding: 0;
-    margin: 0 !important;
-}
-
-.timeline .panel-group {
-    display: block;
-}
-
-.timeline .glyphicon.glyphicon-one-fine-dot:before {
-    content: "\25cf";
-    font-size: 1.5em;
-    color: #0039a6;
-}
-
-.timeline .line {
-    position: absolute;
-    width: 2px;
-    display: block;
-    top: 32px;
-    bottom: 0px;
-    margin-left: 15px;
-    background: #0039a6;
-}
-
 .timeline .line::before,
 .timeline .line::after {
     content: "";
@@ -171,7 +68,7 @@ h4.panel-title {
     height: 0;
     display: block;
     border-radius: 50%;
-    background: #0039a6;
+    background: $gs-primary-alt-color;
 }
 
 .timeline .panel {
@@ -208,7 +105,6 @@ h4.panel-title {
     position: absolute;
     left: -4px;
     top: -14px;
-    /*display: block;*/
     width: 40px;
     height: 40px;
     padding: 0px;
@@ -224,4 +120,21 @@ h4.panel-title {
 .timeline .panel-default>.panel-heading {
     font-family: $gs-grass-font;
     border: 0;
+    background: none;
+    font-weight: 400;
+}
+
+.timeline .panel-default>.panel-heading+.panel-collapse>.panel-body {
+    border-top: 0;
+    padding-top: 0;
+    border-bottom: 0;
+}
+
+h4.panel-title {
+    border: 0;
+}
+
+.panel {
+    -webkit-box-shadow: none;
+    box-shadow: none;
 }


### PR DESCRIPTION
Six fixes, one commit each, all verified by rule-level diffs of the compiled CSS:

1. `.gitter-banner` had a missing semicolon that made Sass parse its nested `a` rule as nested-property syntax; the banner links get their real styling back.
2. The duplicate `.btn-grass` block is merged (the survivor keeps `margin-bottom`, which the cascade never dropped).
3. The two competing global `.card` height clamps (4rem `!important` over a shadowed 5rem) are gone; cards size to content. **Needs a visual check on /download and /about/brand.**
4. The duplicated timeline blocks are consolidated into rules that reproduce the exact cascade result of the pair; the never-winning hardcoded `#0039a6` values are gone (the visible color was and remains the brand alt green).
5. Font Awesome pseudo-elements use the FA7 family name; the overlay gradient derives from `$gs-primary-color`; the two IE `DXImageTransform` filters and a dead `a.external { color: red }` rule are removed.
6. All theme media queries use Bootstrap's breakpoint mixins: the hand-written 991px/992px queries disagreed by a pixel and now share the lg boundary; ramp alpha steps are single-sourced as `$gs-alpha-*` (byte-identical output).

Verified on Hugo 0.113: only `css/style.css` changes across the stack; Dart Sass compiles clean.

Stacked on #698 (stack #700).
