### PR TITLE
scss: add markdown table render hook, and fallback for pre hugo >=0.134

### DIFF
--- a/themes/grass/assets/sass/_variables.scss
+++ b/themes/grass/assets/sass/_variables.scss
@@ -15,6 +15,15 @@ $nav-tabs-link-active-color: $gs-secondary-alt-color;
 // Control listing card title color
 $card-title-color: $gs-grey-dark-color;
 
+// Tables. Content tables get Bootstrap's .table via the render hook in
+// layouts/_markup/render-table.html; these map its look to brand tokens.
+$table-color: $gs-black-color;
+$table-border-color: $gs-grey-alt-color;
+$table-group-separator-color: $gs-grey-alt-color;
+$table-striped-bg: $gs-grey-light-color;
+$table-cell-padding-y: 0.6rem;
+$table-cell-padding-x: 0.9rem;
+
 // Description: This file defines Bootstrap theme variables by mapping them 
 //              to custom color variables. These variables are used to 
 //              customize the appearance of the Bootstrap framework.

--- a/themes/grass/assets/sass/styles/_layout.scss
+++ b/themes/grass/assets/sass/styles/_layout.scss
@@ -44,12 +44,36 @@
     background-color: $gs-grey-light-color !important;
 }
 
-table tr td {
-    padding: 0 10px 0 10px !important;
-}
-
 table img {
     box-shadow: 0 5px 15px $gs-black-color--lightest !important;
+}
+
+// Fallback for Hugo < 0.134, where the render-table.html hook is inert and
+// markdown tables render as bare <table>. Mirrors Bootstrap's striped .table
+// using the same $table-* brand tokens, so the look is identical before and
+// after the Hugo upgrade adds the .table class. The :not(.table) guard makes
+// this disengage automatically once the hook is active.
+table:not(.table) {
+    width: 100%;
+    margin-bottom: 1rem;
+    color: $table-color;
+    border-color: $table-border-color;
+    vertical-align: top;
+
+    th,
+    td {
+        padding: $table-cell-padding-y $table-cell-padding-x;
+        border-bottom: 1px solid $table-border-color;
+    }
+
+    thead th {
+        vertical-align: bottom;
+        border-bottom: 2px solid $table-group-separator-color;
+    }
+
+    tbody tr:nth-of-type(odd)>* {
+        background-color: $table-striped-bg;
+    }
 }
 
 #books table tr td:first-child {

--- a/themes/grass/layouts/_markup/render-table.html
+++ b/themes/grass/layouts/_markup/render-table.html
@@ -1,0 +1,29 @@
+{{- /*
+  Markdown table render hook. Wraps every pipe table in Bootstrap's .table
+  component so styling is driven by the $table-* variables in
+  _variables.scss (mapped to GRASS brand tokens) and by .table-responsive for
+  horizontal scroll on narrow screens. Raw <table> HTML in content is not
+  affected by this hook (for example the history pages' bespoke tables).
+*/ -}}
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      {{- range .THead }}
+      <tr>
+        {{- range . }}
+        <th{{ with .Alignment }} style="text-align: {{ . }};"{{ end }}>{{ .Text }}</th>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </thead>
+    <tbody>
+      {{- range .TBody }}
+      <tr>
+        {{- range . }}
+        <td{{ with .Alignment }} style="text-align: {{ . }};"{{ end }}>{{ .Text }}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
Addresses issue #670

<img width="1288" height="782" alt="Screenshot from 2026-08-19 01-01-00" src="https://github.com/user-attachments/assets/439d6ef1-6862-4dcd-b3db-5db6e7361c0b" />
